### PR TITLE
feat: TLY-9 jwtToken 생성 로직 변경

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/AuthService.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/AuthService.java
@@ -215,6 +215,10 @@ public class AuthService implements LoginUserUseCase, PasswordVerificationUseCas
     }
   }
 
+  /**
+   * 로그아웃
+   * @param token
+   */
   public void logout(String token) {
 
     /*header에 토큰이 존재하지 않을경우*/
@@ -237,7 +241,7 @@ public class AuthService implements LoginUserUseCase, PasswordVerificationUseCas
         InsertBlackListToken.builder()
             .userId(userId)
             .accessToken(accessToken)
-            .duration(ttlProperties.getBlacklistToken())
+            .duration(jwtTokenProvider.getAccessTokenTtl(accessToken))
             .build()
     );
 
@@ -247,6 +251,11 @@ public class AuthService implements LoginUserUseCase, PasswordVerificationUseCas
     log.info("로그아웃 성공");
   }
 
+  /**
+   * blacklist 검증
+   * @param token
+   * @return
+   */
   public boolean isBlacklisted(String token) {
     return
         fetchTokenPort.existsBlackListTokenByAccessToken(token);

--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/JwtTokenProvider.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/JwtTokenProvider.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -171,12 +172,36 @@ public class JwtTokenProvider {
         Jwts.builder()
             .claim("userId", userId)
             .claim("userType", "USER")
+            .setId(UUID.randomUUID().toString().substring(0, 8))
             .setIssuedAt(now)
             .setExpiration(
                 Date.from(Instant.from(instant.plus(duration)))
             )
             .signWith(getSigningKey(), SignatureAlgorithm.HS256)
             .compact();
+  }
+
+  /**
+   * accessToken에서 남은 ttl 추출
+   * @return
+   */
+  public Duration getAccessTokenTtl(String accessToken) {
+    Claims claims = Jwts.parserBuilder()
+        .setSigningKey(getSigningKey())
+        .build()
+        .parseClaimsJws(accessToken)
+        .getBody();
+
+    /*만료 시간*/
+    Date expiration = claims.getExpiration();
+
+    /*현재 시간*/
+    Date now = new Date();
+
+    long ttlMillis = expiration.getTime() - now.getTime();
+
+    return
+        Duration.ofSeconds(ttlMillis);
   }
 
 }

--- a/threadly-apps/app-api/src/test/java/com/threadly/scenario/auth/PasswordVerificationScenarioTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/scenario/auth/PasswordVerificationScenarioTest.java
@@ -32,7 +32,7 @@ public class PasswordVerificationScenarioTest extends BaseApiTest {
   @Transactional
   public void accessProtectedResource_shouldSucceed_afterPasswordVerification() throws Exception {
     //given
-    Thread.sleep(3000);
+//    Thread.sleep(3000);
 
     //when
 


### PR DESCRIPTION
# JWT 개선 및 블랙리스트 토큰 관리 개선 작업

---
# 1. JWT 생성 시 중복 문제 해결

## 기존 문제
- JWT를 동시에 여러 개 생성할 경우, 생성된 JWT 값이 **동일**하게 나오는 문제가 있었다.
- JWT가 동일하게 생성되면, 인증/인가 과정에서 예기치 않은 충돌이나 보안 문제가 발생할 수 있다.
---
## 개선 내용
- **JWT 생성 시 UUID를 기반으로 한 고유한 `tokenId`를 추가**하여, 매번 다른 JWT가 생성되도록 수정했다.

### 적용 코드
```java
Jwts.builder()
    .claim("userId", userId)
    .claim("userType", "USER")
    .setId(UUID.randomUUID().toString().substring(0, 8)) // 고유 tokenId 추가
    .setIssuedAt(now)
    .setExpiration(Date.from(instant.plus(duration)))
    .signWith(getSigningKey(), SignatureAlgorithm.HS256)
    .compact();
```

---

# 2. 블랙리스트 토큰 TTL 개선 작업
---

## 문제 상황

- 블랙리스트 토큰을 등록할 때 **access token의 남은 TTL**이 아닌,  
  **기본 TTL 값**을 적용하고 있었다.
- 이로 인해, access token이 만료되어도 **Redis에 블랙리스트 토큰이 남아있는 문제**가 발생했다.

---

## 개선 내용

- Access Token의 남은 만료 시간을 직접 계산하여,
- 그 값을 블랙리스트 토큰의 TTL로 설정하도록 변경했다.

### 적용 코드

```java
public Duration getAccessTokenTtl(String accessToken) {
    Claims claims = Jwts.parserBuilder()
        .setSigningKey(getSigningKey())
        .build()
        .parseClaimsJws(accessToken)
        .getBody();

    // 만료 시간
    Date expiration = claims.getExpiration();
    
    // 현재 시간
    Date now = new Date();
    
    long ttlMillis = expiration.getTime() - now.getTime();
    
    return Duration.ofSeconds(ttlMillis);
}
```