### PR TITLE
feat: TLY-21 Api 응답 설정

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/config/WebConfig.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/config/WebConfig.java
@@ -11,5 +11,6 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
     configurer.defaultContentType(MediaType.APPLICATION_JSON);
+    configurer.mediaType("json", MediaType.APPLICATION_JSON_UTF8);
   }
 }


### PR DESCRIPTION
# API 응답 Content-Type 설정

---

## 작업 내용

- API 요청에 대한 응답 시 Header에 `Content-Type: application/json` 으로 설정

---

```java
/*WebConfig.class*/
  public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
  configurer.defaultContentType(MediaType.APPLICATION_JSON);
  configurer.mediaType("json", MediaType.APPLICATION_JSON_UTF8);
}
```