### PR TITLE
feat: TLY-16 로그인 시도 횟수 제한 기능 구현

### DIFF
--- a/threadly-adapters/adapter-redis/src/main/java/com/threadly/config/RedisConfig.java
+++ b/threadly-adapters/adapter-redis/src/main/java/com/threadly/config/RedisConfig.java
@@ -39,5 +39,4 @@ public class RedisConfig {
     return template;
   }
 
-
 }

--- a/threadly-adapters/adapter-redis/src/main/java/com/threadly/repository/auth/LoginAttemptRepository.java
+++ b/threadly-adapters/adapter-redis/src/main/java/com/threadly/repository/auth/LoginAttemptRepository.java
@@ -1,0 +1,52 @@
+package com.threadly.repository.auth;
+
+import com.threadly.auth.DeleteLoginAttemptPort;
+import com.threadly.auth.FetchLoginAttemptPort;
+import com.threadly.auth.InsertLoginAttempt;
+import com.threadly.auth.UpsertLoginAttemptPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 로그인 시도 제한 repository
+ */
+@Repository
+@RequiredArgsConstructor
+public class LoginAttemptRepository implements FetchLoginAttemptPort, UpsertLoginAttemptPort,
+    DeleteLoginAttemptPort {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Override
+  public boolean isLoginBlocked(String userId) {
+    return false;
+  }
+
+
+  @Override
+  public Integer getLoginAttemptCount(String userId) {
+    return
+        (Integer) redisTemplate.opsForValue().get(generateKey(userId));
+  }
+
+  @Override
+  public void increaseLoginAttempt(InsertLoginAttempt insertLoginAttempt) {
+    String key = generateKey(insertLoginAttempt.getUserId());
+
+    int loginAttemptCount = insertLoginAttempt.getLoginAttemptCount();
+
+    /*업데이트*/
+    redisTemplate.opsForValue().set(key, ++loginAttemptCount, insertLoginAttempt.getDuration());
+  }
+
+  @Override
+  public void deleteLoginAttempt(String userId) {
+    redisTemplate.delete(generateKey(userId));
+  }
+
+  private String generateKey(String userId) {
+    return "login:attempt:" + userId;
+  }
+
+}

--- a/threadly-adapters/adapter-redis/src/main/java/com/threadly/repository/auth/TestLoginAttemptHelper.java
+++ b/threadly-adapters/adapter-redis/src/main/java/com/threadly/repository/auth/TestLoginAttemptHelper.java
@@ -1,0 +1,34 @@
+package com.threadly.repository.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 테스트시 사용하는 Redis helper
+ */
+@Profile("test")
+@Repository
+@RequiredArgsConstructor
+public class TestLoginAttemptHelper {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  public void insertLoginAttempt(String userId, int attempts) {
+    String key = "login:attempt:" + userId;
+
+    redisTemplate.opsForValue().set(key, attempts);
+  }
+
+  public void clearRedis() {
+    redisTemplate.getConnectionFactory().getConnection().flushAll();
+  }
+
+  public Integer getLoginAttemptCount(String userId) {
+    String key = "login:attempt:" + userId;
+    return
+        (Integer) redisTemplate.opsForValue().get(key);
+  }
+
+}

--- a/threadly-adapters/adapter-redis/src/test/java/com/threadly/RedisTestApplication.java
+++ b/threadly-adapters/adapter-redis/src/test/java/com/threadly/RedisTestApplication.java
@@ -1,7 +1,6 @@
-package com.threadly.repository.token;
+package com.threadly;
 
 
-import com.threadly.RedisModule;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(

--- a/threadly-adapters/adapter-redis/src/test/java/com/threadly/repository/auth/LoginAttemptRepositoryTest.java
+++ b/threadly-adapters/adapter-redis/src/test/java/com/threadly/repository/auth/LoginAttemptRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.threadly.repository.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.threadly.RedisTestApplication;
+import com.threadly.auth.InsertLoginAttempt;
+import java.time.Duration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * LoginAttemptRepository Test
+ */
+@ActiveProfiles("test")
+@SpringBootTest(classes = {RedisTestApplication.class})
+class LoginAttemptRepositoryTest {
+
+  @Autowired
+  private RedisTemplate<String, Object> redisTemplate;
+
+  @Autowired
+  private LoginAttemptRepository loginAttemptRepository;
+
+  @DisplayName("이미 존재하는 값이 있는 경우")
+  @Test
+  public void getLoginAttemptCount() throws Exception {
+    //given
+    String key = "login:attempt:" + "1";
+
+    redisTemplate.opsForValue().set(key, 2);
+
+    //when
+    int result = loginAttemptRepository.getLoginAttemptCount("1");
+
+    //then
+    assertThat(result).isEqualTo(2);
+
+  }
+
+  @DisplayName("이미 존재하는 값이 없는 경우 - null 리턴")
+  @Test
+  public void getLoginAttemptCount_shouldReturnNull_whenKeyNotExists() throws Exception {
+    //given
+    String key = "login:attempt:" + "1";
+
+    redisTemplate.opsForValue().set(key, 2);
+
+    //when
+    Integer result = loginAttemptRepository.getLoginAttemptCount("2");
+
+    //then
+    assertNull(result);
+  }
+
+  @DisplayName("이미 존재하는 값이 있는 경우")
+  @Test
+  public void increaseLoginAttempt_shouldReturnIncreasedValue_whenKeyExists() throws Exception {
+    //given
+    String key = "login:attempt:" + "1";
+    redisTemplate.opsForValue().set(key, 1);
+
+    Integer count = (Integer) redisTemplate.opsForValue().get(key);
+    //when
+    loginAttemptRepository.increaseLoginAttempt(InsertLoginAttempt.builder()
+        .userId("1").loginAttemptCount(count).duration(Duration.ofSeconds(3)).build());
+
+    int result = loginAttemptRepository.getLoginAttemptCount("1");
+
+    //then
+    assertThat(result).isEqualTo(2);
+
+  }
+}

--- a/threadly-adapters/adapter-redis/src/test/java/com/threadly/repository/token/TokenRepositoryTest.java
+++ b/threadly-adapters/adapter-redis/src/test/java/com/threadly/repository/token/TokenRepositoryTest.java
@@ -5,16 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.threadly.RedisTestApplication;
 import com.threadly.token.InsertBlackListToken;
 import com.threadly.token.UpsertRefreshToken;
 import java.time.Duration;
-import net.bytebuddy.utility.dispatcher.JavaDispatcher.Container;
-import org.h2.command.dml.Insert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.context.ActiveProfiles;

--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/LoginAttemptLimiterService.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/LoginAttemptLimiterService.java
@@ -1,0 +1,80 @@
+package com.threadly.auth;
+
+import com.threadly.properties.TtlProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 로그인 시도 횟수 제한 service
+ */
+@Service
+@RequiredArgsConstructor
+public class LoginAttemptLimiterService {
+
+  private final FetchLoginAttemptPort fetchLoginAttemptPort;
+  private final UpsertLoginAttemptPort upsertLoginAttemptPort;
+  private final DeleteLoginAttemptPort deleteLoginAttemptPort;
+
+  private final TtlProperties ttlProperties;
+
+  public boolean checkLoginAttempt(String userId) {
+    Integer count = fetchLoginAttemptPort.getLoginAttemptCount(userId);
+    int loginAttemptCount = (count == null) ? 0 : count;
+
+    if (loginAttemptCount >= 5) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * login Attempt count 체크 로그인 가능하면 true 아니면 false
+   *
+   * @param userId
+   * @return
+   */
+  public void upsertLoginAttempt(String userId) {
+    Integer count = fetchLoginAttemptPort.getLoginAttemptCount(userId);
+    int loginAttemptCount = (count == null) ? 0 : count;
+
+    if (loginAttemptCount >= 5) {
+      return;
+    }
+
+    /*값 업데이트*/
+    upsertLoginAttemptPort.increaseLoginAttempt(InsertLoginAttempt.builder()
+        .userId(userId)
+        .loginAttemptCount(loginAttemptCount)
+        .duration(ttlProperties.getLoginAttempt())
+        .build());
+  }
+
+  /**
+   * increase LoginAttempt
+   *
+   * @param userId
+   */
+  public void incrementLoginAttempt(String userId, int loginAttemptCount) {
+    /*시도횟수 이상인 경우*/
+    if (loginAttemptCount >= 5) {
+      return;
+    }
+
+    /*값 업데이트*/
+    upsertLoginAttemptPort.increaseLoginAttempt(InsertLoginAttempt.builder()
+        .userId(userId)
+        .loginAttemptCount(loginAttemptCount)
+        .duration(ttlProperties.getLoginAttempt())
+        .build());
+  }
+
+  /**
+   * login attempt 삭제
+   * @param userId
+   */
+  public void removeLoginAttempt(String userId) {
+    deleteLoginAttemptPort.deleteLoginAttempt(userId);
+  }
+
+
+}

--- a/threadly-apps/app-api/src/main/java/com/threadly/filter/CustomAuthenticationEntryPoint.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/filter/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.threadly.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.threadly.ErrorCode;
+import com.threadly.auth.LoginAttemptLimiterService;
 import com.threadly.auth.exception.TokenAuthenticationException;
 import com.threadly.auth.exception.UserAuthenticationException;
 import com.threadly.response.ApiResponse;
@@ -23,6 +24,7 @@ import org.springframework.stereotype.Component;
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
   private final ObjectMapper objectMapper;
+  private final LoginAttemptLimiterService loginAttemptLimiterService;
 
   @Override
   public void commence(HttpServletRequest request, HttpServletResponse response,

--- a/threadly-apps/app-api/src/main/resources/application-dev.yml
+++ b/threadly-apps/app-api/src/main/resources/application-dev.yml
@@ -18,3 +18,4 @@ properties:
     blacklist-token: 600
     email-verification: 300
     password-verification: 300
+    login-attempt: 300

--- a/threadly-apps/app-api/src/main/resources/application-prod.yml
+++ b/threadly-apps/app-api/src/main/resources/application-prod.yml
@@ -19,3 +19,4 @@ properties:
     blacklist-token: 900
     email-verification: 600
     password-verification: 600
+    login-attempt: 300

--- a/threadly-apps/app-api/src/test/java/com/threadly/auth/AuthServiceTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/auth/AuthServiceTest.java
@@ -75,9 +75,9 @@ class AuthServiceTest {
     String refreshToken = jwtTokenProvider.generateToken(userId, duration);
 
     insertTokenPort.save(InsertRefreshToken.builder()
-            .userId(userId)
-            .refreshToken(refreshToken)
-            .duration(duration)
+        .userId(userId)
+        .refreshToken(refreshToken)
+        .duration(duration)
         .build());
 
     //when
@@ -93,7 +93,7 @@ class AuthServiceTest {
         () -> assertTrue(isTokenExists),
         () -> assertThat(result.getRefreshToken()).isEqualTo(refreshTokenByUserId)
     );
-
   }
+
 
 }

--- a/threadly-apps/app-api/src/test/java/com/threadly/auth/LoginAttemptLimiterServiceTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/auth/LoginAttemptLimiterServiceTest.java
@@ -1,0 +1,187 @@
+package com.threadly.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.threadly.repository.auth.TestLoginAttemptHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * LoginAttemptLimiterService Test
+ */
+
+@ActiveProfiles("test")
+@SpringBootTest
+@TestMethodOrder(OrderAnnotation.class)
+class LoginAttemptLimiterServiceTest {
+
+  @Autowired
+  private LoginAttemptLimiterService loginAttemptLimiterService;
+
+  @Autowired
+  private TestLoginAttemptHelper testLoginAttemptHelper;
+
+  private static final int MAX_LOGIN_ATTEMPTS = 5;
+
+  @BeforeEach
+  public void setUp() {
+    testLoginAttemptHelper.clearRedis();
+  }
+
+
+  /*
+   * checkLoginAttempt()
+   */
+  /*[Case #1] userId에 일치하는 loginAttempt가 존재하지 않을 경우 true를 리턴해야한다*/
+  @DisplayName("loginAttempt가 존재하지 않을 경우 - true 리턴")
+  @Test
+  public void upsertLoginAttempt_shouldReturnTrue_whenLoginAttemptLessThanFive() throws Exception {
+    //given
+    String userId = "userId";
+
+    //when
+     loginAttemptLimiterService.upsertLoginAttempt(userId);
+    boolean result = loginAttemptLimiterService.checkLoginAttempt(userId);
+
+    //then
+    assertTrue(result);
+  }
+
+  /*[Case #2] userId에 일치하는 loginAttempt가 5이상일 경우 false를 리턴해야한다*/
+  @DisplayName("loginAttempt가 5이상일 경우 - false 리턴")
+  @Test
+  public void upsertLoginAttempt_shouldReturnTrue_whenLoginAttemptReachThanFive() throws Exception {
+    //given
+    String userId = "userId";
+
+    //when
+    testLoginAttemptHelper.insertLoginAttempt(userId, MAX_LOGIN_ATTEMPTS);
+
+    boolean result = loginAttemptLimiterService.checkLoginAttempt(userId);
+
+    //then
+    assertFalse(result);
+  }
+
+  /*[Case #3] userId에 해당하는 값이 존재하지 않는 상황에서 3번 호출된 후 조회 시 3이 나와야 한다*/
+  @DisplayName("userId에 해당하는 값이 존재하지 않는 상황에서 3번 호출된 후 조회 시 3이 나와야 한다")
+  @Test
+  public void upsertLoginAttempt_shouldReturnThree_whenLoginAttemptReachCallThree()
+      throws Exception {
+    //given
+    String userId = "userId";
+
+    //when
+    for (int i = 0; i < 3; i++) {
+      loginAttemptLimiterService.upsertLoginAttempt(userId);
+    }
+
+    loginAttemptLimiterService.upsertLoginAttempt(userId);
+    boolean result = loginAttemptLimiterService.checkLoginAttempt(userId);
+
+    Integer loginAttemptCount = testLoginAttemptHelper.getLoginAttemptCount(userId);
+
+    //then
+    assertTrue(result);
+    assertThat(loginAttemptCount - 1).isEqualTo(3);
+  }
+
+  /*[Case #4]  6번 호출된 후 조회 시 5가 나와야 하고 false가 return 되어야 한다*/
+  @DisplayName("6번 호출된 후 조회 시 5가 나와야 하고 false가 return 되어야 한다")
+  @Test
+  public void upsertLoginAttempt_shouldReturnFive_andFalse_whenLoginAttemptReachCallSix()
+      throws Exception {
+    //given
+    String userId = "userId";
+
+    //when
+    for (int i = 0; i < MAX_LOGIN_ATTEMPTS + 1; i++) {
+      loginAttemptLimiterService.upsertLoginAttempt(userId);
+    }
+
+    loginAttemptLimiterService.upsertLoginAttempt(userId);
+    boolean result = loginAttemptLimiterService.checkLoginAttempt(userId);
+
+    Integer loginAttemptCount = testLoginAttemptHelper.getLoginAttemptCount(userId);
+
+    //then
+    assertFalse(result);
+    assertThat(loginAttemptCount).isEqualTo(MAX_LOGIN_ATTEMPTS);
+  }
+
+  /*
+   * incrementLoginAttempt()
+   */
+  /*[Case #1] loginAttempt가 존재하지 않는 경우, 실행시 1이 더해져야 함*/
+  @DisplayName("loginAttempt가 존재하지 않는 경우, 실행시 1이 더해져야 함")
+  @Test
+  public void incrementLoginAttempt_shouldReturnOne_whenLoginAttemptNotExists() throws Exception {
+    //given
+    String userId = "userId";
+
+    //when
+    loginAttemptLimiterService.incrementLoginAttempt(userId, 0);
+
+    Integer result = testLoginAttemptHelper.getLoginAttemptCount(userId);
+
+    //then
+    assertAll(
+        () -> assertNotNull(result),
+        () -> assertThat(result).isEqualTo(1)
+    );
+  }
+
+  /*[Case #2] loginAttempt가 5인 경우, 더 이상 업데이트 되지 않고 5로 유지되어야 함*/
+  @DisplayName("loginAttempt가 5인 경우, 더 이상 업데이트 되지 않고 5로 유지되어야 함")
+  @Test
+  public void incrementLoginAttempt_shouldReturnFive_whenLoginAttemptIsFive() throws Exception {
+    //given
+    String userId = "userId";
+    testLoginAttemptHelper.insertLoginAttempt(userId, MAX_LOGIN_ATTEMPTS);
+
+    //when
+    loginAttemptLimiterService.incrementLoginAttempt(userId, MAX_LOGIN_ATTEMPTS);
+
+    Integer result = testLoginAttemptHelper.getLoginAttemptCount(userId);
+
+    //then
+    assertAll(
+        () -> assertNotNull(result),
+        () -> assertThat(result).isEqualTo(5)
+    );
+  }
+
+  /*
+   * removeLoginAttempt()
+   */
+  /*[Case #1] login attempt를 삽입한 후 실행, 이후 조회시 null이 나와야한다*/
+  @DisplayName("login attempt를 삽입한 후 실행, 이후 조회시 null이 나와야한다")
+  @Test
+  public void deleteLoginAttempt_shouldReturnNull() throws Exception {
+    //given
+    String userId = "userId";
+    String key = "login:attempt:" + userId;
+
+    testLoginAttemptHelper.insertLoginAttempt(userId, 3);
+
+    //when
+    loginAttemptLimiterService.removeLoginAttempt(userId);
+
+    Integer result = testLoginAttemptHelper.getLoginAttemptCount(userId);
+
+    //then
+    assertNull(result);
+
+  }
+}

--- a/threadly-apps/app-api/src/test/resources/application-test.yml
+++ b/threadly-apps/app-api/src/test/resources/application-test.yml
@@ -19,3 +19,4 @@ properties:
     blacklist-token: 3
     email-verification: 5
     password-verification: 5
+    login-attempt: 5

--- a/threadly-commons/src/main/java/com/threadly/ErrorCode.java
+++ b/threadly-commons/src/main/java/com/threadly/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
   EMAIL_NOT_VERIFIED("TLY2013", "이메일 인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
   EMAIL_VERIFICATION_FAILED("TLY2014", "이메일 인증에 실패했습니다.", HttpStatus.BAD_REQUEST),
   SECOND_VERIFICATION_FAILED("TLY2015", "2차 인증에 실패했습니다.", HttpStatus.BAD_REQUEST),
+  LOGIN_ATTEMPT_EXCEEDED("TLY2016", "로그인 시도 횟수를 초과하였습니다.", HttpStatus.TOO_MANY_REQUESTS),
 
 
   /*Token*/

--- a/threadly-commons/src/main/java/com/threadly/properties/TtlProperties.java
+++ b/threadly-commons/src/main/java/com/threadly/properties/TtlProperties.java
@@ -6,6 +6,9 @@ import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+/**
+ * Ttl
+ */
 @Component
 @ConfigurationProperties(prefix = "properties.ttl")
 @Setter
@@ -17,6 +20,7 @@ public class TtlProperties {
   private long blacklistToken;
   private long emailVerification;
   private long passwordVerification;
+  private long loginAttempt;
 
   public Duration getAccessToken() {
     return Duration.ofSeconds(accessToken);
@@ -36,5 +40,8 @@ public class TtlProperties {
 
   public Duration getPasswordVerification() {
     return Duration.ofSeconds(passwordVerification);
+  }
+  public Duration getLoginAttempt() {
+    return Duration.ofSeconds(loginAttempt);
   }
 }

--- a/threadly-core/core-port/src/main/java/com/threadly/auth/DeleteLoginAttemptPort.java
+++ b/threadly-core/core-port/src/main/java/com/threadly/auth/DeleteLoginAttemptPort.java
@@ -1,0 +1,14 @@
+package com.threadly.auth;
+
+/**
+ * loginAttempt 삭제 port
+ */
+public interface DeleteLoginAttemptPort {
+
+  /**
+   * userId에 해당하는 로그인 attempt 삭제
+   * @param userId
+   */
+  void deleteLoginAttempt(String userId);
+
+}

--- a/threadly-core/core-port/src/main/java/com/threadly/auth/FetchLoginAttemptPort.java
+++ b/threadly-core/core-port/src/main/java/com/threadly/auth/FetchLoginAttemptPort.java
@@ -1,0 +1,22 @@
+package com.threadly.auth;
+
+/**
+ * 로그인 시도 제한 조회 port
+ */
+public interface FetchLoginAttemptPort  {
+
+  /**
+   * redis에서 useId로 조회하여 로그인이 blocked 상태인지 조회
+   * @param userId
+   * @return
+   */
+  boolean isLoginBlocked(String userId);
+
+  /**
+   * userId로 count 조회
+   * @param userId
+   * @return
+   */
+  Integer getLoginAttemptCount(String userId);
+
+}

--- a/threadly-core/core-port/src/main/java/com/threadly/auth/InsertLoginAttempt.java
+++ b/threadly-core/core-port/src/main/java/com/threadly/auth/InsertLoginAttempt.java
@@ -1,0 +1,19 @@
+package com.threadly.auth;
+
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * LoginAttempt 삽입용 DTO
+ */
+@Getter
+@Builder
+public class InsertLoginAttempt {
+
+  private String userId;
+  private int loginAttemptCount;
+
+  private Duration duration;
+
+}

--- a/threadly-core/core-port/src/main/java/com/threadly/auth/UpsertLoginAttemptPort.java
+++ b/threadly-core/core-port/src/main/java/com/threadly/auth/UpsertLoginAttemptPort.java
@@ -1,0 +1,13 @@
+package com.threadly.auth;
+
+public interface UpsertLoginAttemptPort {
+
+  /**
+   * 로그인 시도 횟수 increase
+   * @param insertLoginAttempt
+   * @return
+   */
+  void increaseLoginAttempt(InsertLoginAttempt insertLoginAttempt);
+
+
+}


### PR DESCRIPTION
# 로그인 시도 횟수 제한 기능 구현

---

## 작업 내용

- 로그인 시도 횟수를 제한하는 기능을 추가함.
- 추가한 기능에 대한 테스트 코드를 추가함.

---
## 1. 로그인 시도 횟수를 제한하는 기능 구현

### 주요 변경 사항

- 최대 로그인 시도 횟수를 5회로 제한
- Redis에 `login:attempt:{userId}` 키로 로그인 시도 횟수를 저장
- 로그인 요청 시 `AuthService` 에서 `LoginAttemptLimiterService`를 호출하여 시도 횟수를 체크함
- 로그인 시도 횟수가 5회를 초과할 경우, `LOGIN_ATTEMPT_EXCEEDED` 예외를 발생하고 `HttpStatus.TOO_MANY_REQUESTS`를 응답한다.


---

### 적용 코드

```java

/*AuthService.login()*/
    } catch (BadCredentialsException e) {
    loginAttemptLimiterService.upsertLoginAttempt(userId);
      throw e;
    }
```

```java
/*LoginAttemptRepository*/
public void increaseLoginAttempt(InsertLoginAttempt insertLoginAttempt) {
  String key = generateKey(insertLoginAttempt.getUserId()); //key: login:attempt:{userId} 키 생성

  int loginAttemptCount = insertLoginAttempt.getLoginAttemptCount(); //저장된 로그인 횟수 조회

  /*업데이트*/
  redisTemplate.opsForValue().set(key, ++loginAttemptCount, insertLoginAttempt.getDuration()); //로그인 횟수 증가 후 저장
}

```

### 추가 정보
- Redis에 저장되는 값: `{userId}`를 기반으로 한 로그인 시도 횟수 `Integer` 타입
- 실패한 로그인 시도를 카운트하고  로그인 성공 시 초기화
- TTL을 설정하여 일정 시간이 지나면 자동으로 초기화
 
---

## 2. 테스트 코드

### 테스트 목록
- 잘못된 비밀번호로 5회 미만 로그인시 정상 로그인이 가능한지 검증
- 잘못된 비밀번호로 5회 이상 로그인 후 로그인이 차단되는지 검증
- 잘못된 비밀번호로 로그인 후 정상 로그인 시 횟수가 리셋 되는지 검증
- 잘못된 비밀번호로 5회 이상 로그인하여 로그인이 차단된 후 시간이 Ttl이 지나면 초기화 되는지 검증