### PR TITLE
feat: TLY-32-posts 엔티티 생성

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/CommentLikesEntity.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/CommentLikesEntity.java
@@ -1,0 +1,37 @@
+package com.threadly.entity.post;
+
+
+import com.threadly.entity.user.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+/**
+ * 댓글 좋아요 Entity
+ */
+@Table(name = "comment_likes")
+@Entity
+public class CommentLikesEntity {
+
+  @EmbeddedId
+  private UserIdAndCommentId id;
+
+  @MapsId("commentId")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "comment_id")
+  private PostCommentsEntity comments;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  @MapsId("userId")
+  private UserEntity user;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+}

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostCommentsEntity.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostCommentsEntity.java
@@ -1,0 +1,39 @@
+package com.threadly.entity.post;
+
+
+import com.threadly.entity.BaseEntity;
+import com.threadly.entity.user.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+
+/**
+ * 게시글 댓글 Entity
+ */
+@Table(name = "post_comments")
+@Entity
+public class PostCommentsEntity extends BaseEntity {
+
+  @Id
+  @Column(name = "comment_id")
+  private String commentId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private PostEntity post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private UserEntity user;
+
+  @Column(name = "content")
+  private String content;
+
+
+}

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostEntity.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostEntity.java
@@ -1,0 +1,34 @@
+package com.threadly.entity.post;
+
+import com.threadly.entity.BaseEntity;
+import com.threadly.entity.user.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+/**
+ * 게시글 Entity
+ */
+@Entity
+@Table(name = "posts")
+public class PostEntity extends BaseEntity {
+
+  @Id
+  @Column(name = "post_id")
+  private String postsId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private UserEntity user;
+
+  @Column(name = "content")
+  private String content;
+
+  @Column(name = "view_count")
+  private int viewCount;
+
+}

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostIdAndUserId.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostIdAndUserId.java
@@ -1,0 +1,23 @@
+package com.threadly.entity.post;
+
+
+import jakarta.persistence.Embeddable;
+
+/**
+ * post_likes 복합키
+ */
+@Embeddable
+public class PostIdAndUserId {
+
+  private String postId;
+  private String userId;
+
+  public PostIdAndUserId() {
+  }
+
+  public PostIdAndUserId(String postId, String userId) {
+    this.postId = postId;
+    this.userId = userId;
+  }
+
+}

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostLikesEntity.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/PostLikesEntity.java
@@ -1,0 +1,34 @@
+package com.threadly.entity.post;
+
+
+import com.threadly.entity.user.UserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Table(name = "post_likes")
+@Entity
+public class PostLikesEntity {
+
+  @EmbeddedId
+  private PostIdAndUserId id;
+
+  @MapsId("postId")
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "post_id")
+  private PostEntity post;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  @MapsId("userId")
+  private UserEntity user;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+}

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/UserIdAndCommentId.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/entity/post/UserIdAndCommentId.java
@@ -1,0 +1,23 @@
+package com.threadly.entity.post;
+
+
+import jakarta.persistence.Embeddable;
+
+/**
+ * comment_likes 복합키
+ */
+@Embeddable
+public class UserIdAndCommentId {
+
+  private String commentId;
+  private String userId;
+
+  public UserIdAndCommentId() {
+  }
+
+  public UserIdAndCommentId(String commentId, String userId) {
+    this.commentId = commentId;
+    this.userId = userId;
+  }
+
+}

--- a/threadly-adapters/adapter-persistence/src/main/resources/flyway/V1__create_users_table.sql
+++ b/threadly-adapters/adapter-persistence/src/main/resources/flyway/V1__create_users_table.sql
@@ -1,7 +1,7 @@
 drop table if exists users;
 create table users
 (
-    user_id     varchar(255) not null,
+    user_id     varchar(255) not null primary key ,
     user_name   varchar(255) not null,
     password    varchar(255) not null,
     email       varchar(255) not null,

--- a/threadly-adapters/adapter-persistence/src/main/resources/flyway/V7__create_posts_tables.sql
+++ b/threadly-adapters/adapter-persistence/src/main/resources/flyway/V7__create_posts_tables.sql
@@ -1,0 +1,49 @@
+create table posts
+(
+    post_id     varchar(50) not null primary key,
+    user_id     varchar(50) not null,
+    content     text,
+    view_count  int                  default 0,
+    created_at  timestamp   not null default current_timestamp,
+    modified_at timestamp   not null default current_timestamp,
+    foreign key (user_id) references users (user_id)
+);
+
+create table post_likes
+(
+    post_id    varchar(50) not null,
+    user_id    varchar(50) not null,
+    created_at timestamp   not null default current_timestamp,
+    primary key (post_id, user_id),
+    foreign key (post_id) references posts (post_id) on delete cascade,
+    foreign key (user_id) references users (user_id) on delete cascade
+);
+
+create table post_comments
+(
+    comment_id  varchar(50) not null primary key,
+    post_id     varchar(50) not null,
+    user_id     varchar(50) not null,
+    content     text        not null,
+    created_at  timestamp   not null default current_timestamp,
+    modified_at timestamp   not null default current_timestamp,
+    foreign key (post_id) references posts (post_id) on delete cascade,
+    foreign key (user_id) references users (user_id) on delete cascade
+);
+
+create table comment_likes
+(
+    comment_id varchar(50) not null,
+    user_id    varchar(50) not null,
+    created_at timestamp   not null default current_timestamp,
+    primary key (comment_id, user_id),
+    foreign key (comment_id) references post_comments (comment_id) on delete cascade,
+    foreign key (user_id) references users (user_id) on delete cascade
+);
+
+
+
+
+
+
+


### PR DESCRIPTION
# feat: 게시글 관련 엔티티 및 테이블 생성


## 작업 내용

- 게시글 관련 엔티티 및 테이블 생성

### UML

```mermaid
erDiagram
    users ||--o{ posts: "writes"
    users ||--o{ post_likes: "likes"
    users ||--o{ post_comments: "comments"
    users ||--o{ comment_likes: "likes comment"
    posts ||--o{ post_likes: "liked"
    posts ||--o{ post_comments: "has comments"
    post_comments ||--o{ comment_likes: "has likes"

    users {
        string user_id
    }

    posts {
        string post_id
        string user_id
        string content
        int view_count
        datetime created_at
        datetime updated_at
    }

    post_likes {
        string post_id
        string user_id
        datetime created_at
    }

    post_comments {
        string comment_id
        string post_id
        string user_id
        string content
        datetime created_at
        datetime updated_at
    }

    comment_likes {
        string comment_id
        string user_id
        datetime created_at
    }
```

---

## 엔티티 설명

### 1. `posts`

- 게시글을 저장하는 테이블
- 하나의 사용자가 여러 게시글을 작성할 수 있는 구조 (`user_id`) FK
- 컬럼
    - `post_id` : 게시글 고유 식별자(PK), nanoId
    - `user_id` : 작성자 ID (FK -> `users`)
    - `content` : 게시글 본문
    - `view_count` : 조회수
    - `created_at`, `modified_at` : 생성 및 수정 시간

### 2. `post_likes`

- 게시글에 대한 좋아요 기록을 저장
- 한 사용자가 같은 게시글에 중복해서 좋아요를 누를 수 없도록 복합키(`post_id`, `user_id`) 설정
- 게시글 또는 사용자 삭제 시 자동으로 좋아요 레코드 삭제됨 (`on delete cascade`)
    - 컬럼
        - `post_id` : 게시글 ID (PK, FK -> `posts`)
        - `user_id` : 사용자 ID (PK, FK -> `users`)
        - `created_at` : 생성 시간

### 3. `post_comments`

- 게시글에 달린 댓글을 저장
- 각 댓글은 작성자(`user_id`)와 게시글(`post_id`)에 속함
- 컬럼
    - `comment_id` : 댓글 ID nanoId (PK)
    - `post_id` : 게시글 ID (FK -> `posts`)
    - `user_id` : 사용자 ID (FK -> `users`)
    - `content` : 댓글 본문
    - `created_at`, `modified_at` : 생성 및 수정 시간

### 4. `comment_likes`

- 댓글에 대한 좋아요 기록을 저장
- 한 사용자가 하나의 댓글에 한 번만 좋아요 가능
- 댓글 또는 사용자 삭제 시 자동으로 댓글의 좋아요 레코드 삭제됨 (`on delete cascade`)
- 컬럼
    - `comment_id` : 댓글 좋아요 ID (PK), nanoId
    - `user_id` : 사용자 ID (PK, FK -> `users`)
    - `created_at` : 생성 시간

---
## 향후 계획
- 이후 게시글의 이미지를 저장하는 `posts_images` 엔티티 생성
