### PR TITLE
refactor: TLY-65-app-api 모듈 테스트를 도메인 기반 패키지 구조로 개편

### DIFF
--- a/threadly-apps/app-api/src/test/java/com/threadly/SampleTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/SampleTest.java
@@ -1,7 +1,7 @@
 package com.threadly;
 
 
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.testsupport.fixture.posts.PostCommentFixtureLoader;
 import com.threadly.testsupport.fixture.posts.PostLikeFixtureLoader;
 import org.junit.jupiter.api.BeforeEach;

--- a/threadly-apps/app-api/src/test/java/com/threadly/auth/controller/AuthControllerTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/auth/controller/AuthControllerTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.auth;
+package com.threadly.auth.controller;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static com.threadly.utils.TestConstants.USER_EMAIL_NOT_VERIFIED;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/BasePostApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/BasePostApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post;
+package com.threadly.post.controller;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/CreatePostApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/CreatePostApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post;
+package com.threadly.post.controller;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/GetPostApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/GetPostApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post;
+package com.threadly.post.controller;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/UpdatePostApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/UpdatePostApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post;
+package com.threadly.post.controller;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_2;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/UpdatePostStatusApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/UpdatePostStatusApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post;
+package com.threadly.post.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/CreatePostCommentApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/CreatePostCommentApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.comment;
+package com.threadly.post.controller.comment;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.comment.create.CreatePostCommentApiResponse;
 import com.threadly.testsupport.fixture.posts.PostFixtureLoader;
 import org.junit.jupiter.api.BeforeEach;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/GetPostCommentApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/GetPostCommentApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.comment;
+package com.threadly.post.controller.comment;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.comment.get.GetPostCommentListApiResponse;
 import com.threadly.testsupport.fixture.posts.PostCommentFixtureLoader;
 import java.time.LocalDateTime;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/UpdatePostCommentApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/UpdatePostCommentApiTest.java
@@ -1,11 +1,11 @@
-package com.threadly.controller.post.comment;
+package com.threadly.post.controller.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.testsupport.fixture.posts.PostCommentFixtureLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.ClassOrderer;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/CreatePostCommentLikeApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/CreatePostCommentLikeApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.comment.like;
+package com.threadly.post.controller.comment.like;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.like.comment.LikePostCommentApiResponse;
 import com.threadly.testsupport.fixture.posts.PostCommentFixtureLoader;
 import java.util.List;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/DeletePostCommentLikeApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/DeletePostCommentLikeApiTest.java
@@ -1,10 +1,10 @@
-package com.threadly.controller.post.comment.like;
+package com.threadly.post.controller.comment.like;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.threadly.CommonResponse;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.like.comment.LikePostCommentApiResponse;
 import com.threadly.testsupport.fixture.posts.PostCommentLikeFixtureLoader;
 import org.junit.jupiter.api.BeforeEach;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/GetPostCommentLikeApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/comment/like/GetPostCommentLikeApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.comment.like;
+package com.threadly.post.controller.comment.like;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.comment.get.GetPostCommentListApiResponse;
 import com.threadly.post.like.comment.GetPostCommentLikersApiResponse;
 import com.threadly.testsupport.fixture.posts.PostCommentLikeFixtureLoader;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/DeletePostLikeApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/DeletePostLikeApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.like;
+package com.threadly.post.controller.like;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.like.post.LikePostApiResponse;
 import com.threadly.testsupport.fixture.posts.PostFixtureLoader;
 import java.util.List;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/GetPostLikeApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/GetPostLikeApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.like;
+package com.threadly.post.controller.like;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.engagement.GetPostEngagementApiResponse;
 import com.threadly.post.like.post.GetPostLikersApiResponse;
 import com.threadly.testsupport.fixture.posts.PostLikeFixtureLoader;

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/LikePostApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/like/LikePostApiTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.post.like;
+package com.threadly.post.controller.like;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.threadly.CommonResponse;
 import com.threadly.ErrorCode;
-import com.threadly.controller.post.BasePostApiTest;
+import com.threadly.post.controller.BasePostApiTest;
 import com.threadly.post.like.post.LikePostApiResponse;
 import com.threadly.testsupport.fixture.posts.PostFixtureLoader;
 import java.util.List;

--- a/threadly-apps/app-api/src/test/java/com/threadly/user/controller/UserControllerTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/user/controller/UserControllerTest.java
@@ -1,4 +1,4 @@
-package com.threadly.controller.user;
+package com.threadly.user.controller;
 
 import static com.threadly.utils.TestConstants.EMAIL_VERIFIED_USER_1;
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## 개요

기존 app-api 모듈의 테스트코드는 controller, request 등 수직 계층 기반의 구조로 구성되어 있었음.  
이번 커밋에서는 유지보수성과 응집도를 높이기 위해 도메인 기반 구조로 전면 리팩토링을 진행함.

## 주요 변경 사항

- 각 도메인의 책임과 경계를 명확히 하여 구조적 응집도 향상

## 고려사항
- 이후 도메인 추가 시 동일한 구조로 확장 가능


---