### PR TITLE
refactor: TLY-61 PostController를 책임 단위로 분리

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentController.java
@@ -1,0 +1,124 @@
+package com.threadly.post.controller;
+
+import com.threadly.post.comment.create.CreatePostCommentApiResponse;
+import com.threadly.post.comment.create.CreatePostCommentCommand;
+import com.threadly.post.comment.create.CreatePostCommentUseCase;
+import com.threadly.post.comment.delete.DeletePostCommentCommand;
+import com.threadly.post.comment.delete.DeletePostCommentUseCase;
+import com.threadly.post.comment.get.GetPostCommentListApiResponse;
+import com.threadly.post.comment.get.GetPostCommentListQuery;
+import com.threadly.post.comment.get.GetPostCommentUseCase;
+import com.threadly.post.request.CreatePostCommentRequest;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * 게시글 댓글 생성, 삭제, 조회 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostCommentController {
+
+
+  private final CreatePostCommentUseCase createPostCommentUseCase;
+  private final DeletePostCommentUseCase deletePostCommentUseCase;
+  private final GetPostCommentUseCase getPostCommentUseCase;
+
+  /*
+   * 게시글 댓글 생성 - POST /api/posts/{postId}/comments
+   * 게시글 댓글 삭제 - DELETE /api/posts/{postId}/comments
+   * 게시글 댓글 목록 조회 - GET /api/posts/{postId}/comments
+   */
+
+
+  /**
+   * 게시글 댓글 목록 커서 기반 조회
+   *
+   * @param postId
+   * @param cursorCommentedAt
+   * @param cursorCommentId
+   * @param limit
+   * @return
+   */
+  @GetMapping("/{postId}/comments")
+  public ResponseEntity<GetPostCommentListApiResponse> getPostComments(@PathVariable String postId,
+      @RequestParam(value = "cursor_commented_at", required = false) LocalDateTime cursorCommentedAt,
+      @RequestParam(value = "cursor_comment_id", required = false) String cursorCommentId,
+      @RequestParam(value = "limit", defaultValue = "10") int limit
+  ) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(200).body(
+        getPostCommentUseCase.getPostCommentDetailListForUser(
+            new GetPostCommentListQuery(
+                postId,
+                userId,
+                cursorCommentedAt,
+                cursorCommentId,
+                limit
+            )
+        )
+    );
+  }
+
+
+  /**
+   * 게시글 댓글 생성
+   *
+   * @param postId
+   * @param request
+   * @return createPostCommentApiResponse
+   */
+  @PostMapping("/{postId}/comments")
+  public ResponseEntity<CreatePostCommentApiResponse> createPostComment(
+      @PathVariable("postId") String postId, @RequestBody CreatePostCommentRequest request) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(201).body(
+        createPostCommentUseCase.createPostComment(
+            new CreatePostCommentCommand(
+                postId,
+                userId,
+                request.content()
+            )
+        )
+    );
+  }
+
+  /**
+   * 게시글 댓글 삭제
+   *
+   * @param commentId
+   * @return
+   */
+  @DeleteMapping("/{postId}/comments/{commentId}")
+  public ResponseEntity<Void> deletePostComment(@PathVariable("postId") String postId,
+      @PathVariable("commentId") String commentId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    deletePostCommentUseCase.softDeletePostComment(
+        new DeletePostCommentCommand(
+            userId,
+            postId,
+            commentId)
+    );
+
+    return ResponseEntity.status(204).build();
+  }
+}

--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentLikeController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentLikeController.java
@@ -1,0 +1,113 @@
+package com.threadly.post.controller;
+
+import com.threadly.post.like.comment.GetPostCommentLikersApiResponse;
+import com.threadly.post.like.comment.GetPostCommentLikersQuery;
+import com.threadly.post.like.comment.GetPostCommentLikersUseCase;
+import com.threadly.post.like.comment.LikePostCommentApiResponse;
+import com.threadly.post.like.comment.LikePostCommentCommand;
+import com.threadly.post.like.comment.LikePostCommentUseCase;
+import com.threadly.post.like.comment.UnlikePostCommentUseCase;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * 게시글 댓글 좋아요, 취소, 조회 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostCommentLikeController {
+
+  private final GetPostCommentLikersUseCase getPostCommentLikersUseCase;
+  private final LikePostCommentUseCase likePostCommentUseCase;
+  private final UnlikePostCommentUseCase unlikePostCommentUseCase;
+
+  /*
+   * 게시글 댓글 좋아요 - POST /api/posts/{postId}/comments/{commentId}/likes
+   * 게시글 댓글 좋아요 취소 - DELETE /api/posts/{postId}/comments/{commentId}/likes
+   * 게시글 댓글 좋아요 목록 조회 - GET /api/posts/{postId}/comments/{commentsId}/likes
+   */
+
+  /**
+   * 게시글 댓글 좋아요 목록 조회
+   *
+   * @param postId
+   * @param commentId
+   * @param cursorLikedAt
+   * @param cursorLikerId
+   * @return
+   */
+  @GetMapping("/{postId}/comments/{commentId}/likes")
+  public ResponseEntity<GetPostCommentLikersApiResponse> getPostCommentLikers(
+      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId,
+      @RequestParam(value = "cursor_liked_at", required = false) LocalDateTime cursorLikedAt,
+      @RequestParam(value = "cursor_liker_id", required = false) String cursorLikerId,
+      @RequestParam(value = "limit", defaultValue = "10") int limit
+  ) {
+
+    return ResponseEntity.status(200).body(getPostCommentLikersUseCase.getPostCommentLikers(
+            new GetPostCommentLikersQuery(
+                postId, commentId, cursorLikedAt, cursorLikerId, limit)
+        )
+    );
+  }
+
+
+  /**
+   * 게시글 댓글 좋아요
+   *
+   * @param postId
+   * @param commentId
+   * @return
+   */
+  @PostMapping("/{postId}/comments/{commentId}/likes")
+  public ResponseEntity<LikePostCommentApiResponse> likePostComment(
+      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId
+  ) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    LikePostCommentApiResponse likePostCommentApiResponse = likePostCommentUseCase.likePostComment(
+        new LikePostCommentCommand(
+            commentId,
+            userId
+        )
+    );
+
+    return ResponseEntity.status(200).body(likePostCommentApiResponse);
+  }
+
+  /**
+   * 게시글 댓글 좋아요 삭제
+   *
+   * @return
+   */
+  @DeleteMapping("/{postId}/comments/{commentId}/likes")
+  public ResponseEntity<LikePostCommentApiResponse> cancelPostCommentLike(
+      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(204).body(
+        unlikePostCommentUseCase.cancelPostCommentLike(
+            new LikePostCommentCommand(
+                commentId,
+                userId
+            )
+        )
+    );
+  }
+
+
+}

--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostController.java
@@ -1,43 +1,17 @@
 package com.threadly.post.controller;
 
-import com.threadly.post.request.CreatePostCommentRequest;
-import com.threadly.post.request.CreatePostRequest;
-import com.threadly.post.request.UpdatePostRequest;
-import com.threadly.post.comment.create.CreatePostCommentApiResponse;
-import com.threadly.post.comment.create.CreatePostCommentCommand;
-import com.threadly.post.comment.create.CreatePostCommentUseCase;
-import com.threadly.post.comment.delete.DeletePostCommentCommand;
-import com.threadly.post.comment.delete.DeletePostCommentUseCase;
-import com.threadly.post.comment.get.GetPostCommentListApiResponse;
-import com.threadly.post.comment.get.GetPostCommentListQuery;
-import com.threadly.post.comment.get.GetPostCommentUseCase;
 import com.threadly.post.create.CreatePostApiResponse;
 import com.threadly.post.create.CreatePostCommand;
 import com.threadly.post.create.CreatePostUseCase;
 import com.threadly.post.delete.DeletePostCommand;
 import com.threadly.post.delete.DeletePostUseCase;
-import com.threadly.post.engagement.GetPostEngagementApiResponse;
-import com.threadly.post.engagement.GetPostEngagementQuery;
-import com.threadly.post.engagement.GetPostEngagementUseCase;
 import com.threadly.post.get.GetPostDetailApiResponse;
 import com.threadly.post.get.GetPostDetailListApiResponse;
 import com.threadly.post.get.GetPostListQuery;
 import com.threadly.post.get.GetPostQuery;
 import com.threadly.post.get.GetPostUseCase;
-import com.threadly.post.like.comment.GetPostCommentLikersApiResponse;
-import com.threadly.post.like.comment.GetPostCommentLikersQuery;
-import com.threadly.post.like.comment.GetPostCommentLikersUseCase;
-import com.threadly.post.like.comment.LikePostCommentApiResponse;
-import com.threadly.post.like.comment.LikePostCommentCommand;
-import com.threadly.post.like.comment.LikePostCommentUseCase;
-import com.threadly.post.like.comment.UnlikePostCommentUseCase;
-import com.threadly.post.like.post.GetPostLikersApiResponse;
-import com.threadly.post.like.post.GetPostLikersQuery;
-import com.threadly.post.like.post.GetPostLikersUseCase;
-import com.threadly.post.like.post.LikePostApiResponse;
-import com.threadly.post.like.post.LikePostCommand;
-import com.threadly.post.like.post.LikePostUseCase;
-import com.threadly.post.like.post.UnlikePostUseCase;
+import com.threadly.post.request.CreatePostRequest;
+import com.threadly.post.request.UpdatePostRequest;
 import com.threadly.post.update.UpdatePostApiResponse;
 import com.threadly.post.update.UpdatePostCommand;
 import com.threadly.post.update.UpdatePostUseCase;
@@ -57,10 +31,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/*TODO 게시글과 댓글 컨트롤러 분리 고려*/
 
 /**
- * post controller
+ * 게시글 등록, 조회, 삭제 컨트롤러
  */
 @RestController
 @RequestMapping("/api/posts")
@@ -70,21 +43,7 @@ public class PostController {
   private final CreatePostUseCase createPostUseCase;
   private final UpdatePostUseCase updatePostUseCase;
   private final GetPostUseCase getPostUseCase;
-  private final LikePostUseCase likePostUseCase;
-  private final UnlikePostUseCase unlikePostUseCase;
-  private final GetPostEngagementUseCase getPostEngagementUsecase;
-  private final GetPostLikersUseCase getPostLikersUseCase;
   private final DeletePostUseCase deletePostUseCase;
-
-  private final CreatePostCommentUseCase createPostCommentUseCase;
-  private final DeletePostCommentUseCase deletePostCommentUseCase;
-  private final GetPostCommentUseCase getPostCommentUseCase;
-  private final GetPostCommentLikersUseCase getPostCommentLikersUseCase;
-//  private final GetPostCommentEngagementUseCase getPostCommentEngagementUseCase;
-
-
-  private final LikePostCommentUseCase likePostCommentUseCase;
-  private final UnlikePostCommentUseCase unlikePostCommentUseCase;
 
   /*
    * 게시글 저장 - POST /api/posts
@@ -92,16 +51,6 @@ public class PostController {
    * 게시글 조회 - GET /api/posts/{postId}
    * 게시글 목록 조회 - GET /api/posts
    * 게시글 수정 - PATCH /api/posts/{postId}
-   * 게시글 통계 - GET /api/posts/{postId}/stats
-   * 게시글 좋아요 - POST /api/posts/{postId}/likes
-   * 게시글 활동 요약 조회 - GET /api/posts/{postId}/engagement
-   * 게시글 활동 좋아요 목록조회 - GET /api/posts/{postId}/engagement/likes
-   * 게시글 댓글 생성 - POST /api/posts/{postId}/comments
-   * 게시글 댓글 삭제 - DELETE /api/posts/{postId}/comments
-   * 게시글 댓글 목록 조회 - GET /api/posts/{postId}/comments
-   * 게시글 댓글 좋아요 - POST /api/posts/{postId}/comments/{commentId}/likes
-   * 게시글 댓글 좋아요 취소 - DELETE /api/posts/{postId}/comments/{commentId}/likes
-   * 게시글 댓글 좋아요 목록 조회 - GET /api/posts/{postId}/comments/{commentsId}/likes
    */
 
   /**
@@ -147,45 +96,6 @@ public class PostController {
     );
   }
 
-  /**
-   * 게시글 좋아요 요약 조회
-   *
-   * @param postId
-   * @return
-   */
-  @GetMapping("/{postId}/engagement")
-  public ResponseEntity<GetPostEngagementApiResponse> getPostEngagement(
-      @PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(200).body(getPostEngagementUsecase.getPostEngagement(
-        new GetPostEngagementQuery(
-            postId, userId
-        )
-    ));
-  }
-
-
-  /**
-   * 특정 게시글 좋아요 누른 사용자 커서기반 조회
-   *
-   * @return
-   */
-  @GetMapping("/{postId}/engagement/likes")
-  public ResponseEntity<GetPostLikersApiResponse> getPostLikers(
-      @RequestParam(value = "cursor_liked_at", required = false) LocalDateTime cursorLikedAt,
-      @RequestParam(value = "cursor_liker_id", required = false) String cursorLikerId,
-      @RequestParam(value = "limit", defaultValue = "10") int limit,
-      @PathVariable("postId") String postId
-  ) {
-
-    return ResponseEntity.status(200).body(getPostLikersUseCase.getPostLikers(
-        new GetPostLikersQuery(
-            postId, cursorLikedAt, cursorLikerId, limit
-        )
-    ));
-  }
 
   /**
    * 게시글 생성
@@ -247,201 +157,4 @@ public class PostController {
 
     return ResponseEntity.status(200).build();
   }
-
-  /**
-   * 게시글 좋아요
-   *
-   * @param postId
-   * @return
-   */
-  @PostMapping("/{postId}/likes")
-  public ResponseEntity<LikePostApiResponse> likePost(@PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(200).body(
-        likePostUseCase.likePost(
-            new LikePostCommand(
-                postId,
-                userId
-            )
-        )
-    );
-  }
-
-  /**
-   * 게시글 좋아요 취소
-   *
-   * @param postId
-   * @return
-   */
-  @DeleteMapping("/{postId}/likes")
-  public ResponseEntity<LikePostApiResponse> cancelPostLike(@PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(204).body(unlikePostUseCase.cancelLikePost(
-        new LikePostCommand(
-            postId,
-            userId
-        )
-    ));
-  }
-
-//  @GetMapping("/{postId}/comments/{commentId}/engagement")
-//  public ResponseEntity<GetPostCommentEngagementApiResponse> getPostCommentEngagement() {
-//
-//    return null;
-//  }
-
-  /**
-   * 게시글 댓글 목록 커서 기반 조회
-   *
-   * @param postId
-   * @param cursorCommentedAt
-   * @param cursorCommentId
-   * @param limit
-   * @return
-   */
-  @GetMapping("/{postId}/comments")
-  public ResponseEntity<GetPostCommentListApiResponse> getPostComments(@PathVariable String postId,
-      @RequestParam(value = "cursor_commented_at", required = false) LocalDateTime cursorCommentedAt,
-      @RequestParam(value = "cursor_comment_id", required = false) String cursorCommentId,
-      @RequestParam(value = "limit", defaultValue = "10") int limit
-  ) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(200).body(
-        getPostCommentUseCase.getPostCommentDetailListForUser(
-            new GetPostCommentListQuery(
-                postId,
-                userId,
-                cursorCommentedAt,
-                cursorCommentId,
-                limit
-            )
-        )
-    );
-  }
-
-
-  /**
-   * 게시글 댓글 생성
-   *
-   * @param postId
-   * @param request
-   * @return createPostCommentApiResponse
-   */
-  @PostMapping("/{postId}/comments")
-  public ResponseEntity<CreatePostCommentApiResponse> createPostComment(
-      @PathVariable("postId") String postId, @RequestBody CreatePostCommentRequest request) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(201).body(
-        createPostCommentUseCase.createPostComment(
-            new CreatePostCommentCommand(
-                postId,
-                userId,
-                request.content()
-            )
-        )
-    );
-  }
-
-  /**
-   * 게시글 댓글 삭제
-   *
-   * @param commentId
-   * @return
-   */
-  @DeleteMapping("/{postId}/comments/{commentId}")
-  public ResponseEntity<Void> deletePostComment(@PathVariable("postId") String postId,
-      @PathVariable("commentId") String commentId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    deletePostCommentUseCase.softDeletePostComment(
-        new DeletePostCommentCommand(
-            userId,
-            postId,
-            commentId)
-    );
-
-    return ResponseEntity.status(204).build();
-  }
-
-
-  /**
-   * 게시글 댓글 좋아요 목록 조회
-   *
-   * @param postId
-   * @param commentId
-   * @param cursorLikedAt
-   * @param cursorLikerId
-   * @return
-   */
-  @GetMapping("/{postId}/comments/{commentId}/likes")
-  public ResponseEntity<GetPostCommentLikersApiResponse> getPostCommentLikers(
-      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId,
-      @RequestParam(value = "cursor_liked_at", required = false) LocalDateTime cursorLikedAt,
-      @RequestParam(value = "cursor_liker_id", required = false) String cursorLikerId,
-      @RequestParam(value = "limit", defaultValue = "10") int limit
-  ) {
-
-    return ResponseEntity.status(200).body(getPostCommentLikersUseCase.getPostCommentLikers(
-            new GetPostCommentLikersQuery(
-                postId, commentId, cursorLikedAt, cursorLikerId, limit)
-        )
-    );
-  }
-
-
-  /**
-   * 게시글 댓글 좋아요
-   *
-   * @param postId
-   * @param commentId
-   * @return
-   */
-  @PostMapping("/{postId}/comments/{commentId}/likes")
-  public ResponseEntity<LikePostCommentApiResponse> likePostComment(
-      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId
-  ) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    LikePostCommentApiResponse likePostCommentApiResponse = likePostCommentUseCase.likePostComment(
-        new LikePostCommentCommand(
-            commentId,
-            userId
-        )
-    );
-
-    return ResponseEntity.status(200).body(likePostCommentApiResponse);
-  }
-
-  /**
-   * 게시글 댓글 좋아요 삭제
-   *
-   * @return
-   */
-  @DeleteMapping("/{postId}/comments/{commentId}/likes")
-  public ResponseEntity<LikePostCommentApiResponse> cancelPostCommentLike(
-      @PathVariable("postId") String postId, @PathVariable("commentId") String commentId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
-    return ResponseEntity.status(204).body(
-        unlikePostCommentUseCase.cancelPostCommentLike(
-            new LikePostCommentCommand(
-                commentId,
-                userId
-            )
-        )
-    );
-  }
-
-
 }

--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostLikeController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostLikeController.java
@@ -1,0 +1,128 @@
+package com.threadly.post.controller;
+
+import com.threadly.post.engagement.GetPostEngagementApiResponse;
+import com.threadly.post.engagement.GetPostEngagementQuery;
+import com.threadly.post.engagement.GetPostEngagementUseCase;
+import com.threadly.post.like.post.GetPostLikersApiResponse;
+import com.threadly.post.like.post.GetPostLikersQuery;
+import com.threadly.post.like.post.GetPostLikersUseCase;
+import com.threadly.post.like.post.LikePostApiResponse;
+import com.threadly.post.like.post.LikePostCommand;
+import com.threadly.post.like.post.LikePostUseCase;
+import com.threadly.post.like.post.UnlikePostUseCase;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+
+/**
+ * 게시글 좋아요, 취소, 목록, 요약 조회 컨트롤러
+ */
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostLikeController {
+
+  private final LikePostUseCase likePostUseCase;
+  private final UnlikePostUseCase unlikePostUseCase;
+  private final GetPostEngagementUseCase getPostEngagementUsecase;
+  private final GetPostLikersUseCase getPostLikersUseCase;
+
+  /*
+   * 게시글 좋아요 - POST /api/posts/{postId}/likes
+   * 게시글 좋아요 취소 - DELETE /api/posts/{postId}/likes
+   * 게시글 활동 요약 조회 - GET /api/posts/{postId}/engagement
+   * 게시글 활동 좋아요 목록조회 - GET /api/posts/{postId}/engagement/likes
+   */
+
+  /**
+   * 게시글 좋아요 요약 조회
+   *
+   * @param postId
+   * @return
+   */
+  @GetMapping("/{postId}/engagement")
+  public ResponseEntity<GetPostEngagementApiResponse> getPostEngagement(
+      @PathVariable("postId") String postId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(200).body(getPostEngagementUsecase.getPostEngagement(
+        new GetPostEngagementQuery(
+            postId, userId
+        )
+    ));
+  }
+
+
+  /**
+   * 특정 게시글 좋아요 누른 사용자 커서기반 조회
+   *
+   * @return
+   */
+  @GetMapping("/{postId}/engagement/likes")
+  public ResponseEntity<GetPostLikersApiResponse> getPostLikers(
+      @RequestParam(value = "cursor_liked_at", required = false) LocalDateTime cursorLikedAt,
+      @RequestParam(value = "cursor_liker_id", required = false) String cursorLikerId,
+      @RequestParam(value = "limit", defaultValue = "10") int limit,
+      @PathVariable("postId") String postId
+  ) {
+
+    return ResponseEntity.status(200).body(getPostLikersUseCase.getPostLikers(
+        new GetPostLikersQuery(
+            postId, cursorLikedAt, cursorLikerId, limit
+        )
+    ));
+  }
+
+
+  /**
+   * 게시글 좋아요
+   *
+   * @param postId
+   * @return
+   */
+  @PostMapping("/{postId}/likes")
+  public ResponseEntity<LikePostApiResponse> likePost(@PathVariable("postId") String postId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(200).body(
+        likePostUseCase.likePost(
+            new LikePostCommand(
+                postId,
+                userId
+            )
+        )
+    );
+  }
+
+  /**
+   * 게시글 좋아요 취소
+   *
+   * @param postId
+   * @return
+   */
+  @DeleteMapping("/{postId}/likes")
+  public ResponseEntity<LikePostApiResponse> cancelPostLike(@PathVariable("postId") String postId) {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    String userId = (String) auth.getCredentials();
+
+    return ResponseEntity.status(204).body(unlikePostUseCase.cancelLikePost(
+        new LikePostCommand(
+            postId,
+            userId
+        )
+    ));
+  }
+
+}


### PR DESCRIPTION
## 개요

기존 PostController는 게시글, 댓글, 좋아요 등 다양한 기능을 모두 담당하고 있어  
단일 책임 원칙(SRP)을 위반하고 있었고, 유지보수성과 테스트 편의성이 떨어지는 구조였음.  
이에 따라 게시글 관련 기능을 책임 단위로 분리하여 컨트롤러 구조를 재정비함.

## 주요 변경 사항

- 기존 PostController에 포함된 메서드들을 다음과 같이 분리
  - 게시글 CRUD → `PostController`
  - 게시글 좋아요 기능 → `PostLikeController`
  - 게시글 댓글 기능 → `PostCommentController`
  - 게시글 댓글 좋아요 기능 → `PostCommentLikeController`
- 각 컨트롤러는 해당 기능에만 집중하도록 책임을 분리하고, 관련 유스케이스만 주입받도록 구성
- URI는 기존과 동일하게 `/api/posts/**` 하위 경로 유지됨

## 고려사항

- URI 스펙은 변경 없음 (기존 클라이언트 연동 영향 없음)
- 시나리오 확장 시 각 컨트롤러별로 기능 추가가 용이해짐