### PR TITLE
refactor: TLY-66 인증 사용자 접근 방식 개선 및 AuthenticationUser 구조 정리

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/AuthenticationUser.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/AuthenticationUser.java
@@ -1,24 +1,59 @@
 package com.threadly.auth;
 
 import java.util.Collection;
+import java.util.List;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
-public class AuthenticationUser extends User {
+public class AuthenticationUser implements UserDetails {
 
-//  private String userName;
-  private String email;
-//  private String password;
-  private String phone;
+  private final String userId;
+  private final String email;
+  private final String phone;
+  private final String password;
 
-  public AuthenticationUser(String username, String password,
-      Collection<? extends GrantedAuthority> authorities, String email, String phone) {
-    super(username, password, authorities);
-//    this.userName = username;
-//    this.password = password;
+  public AuthenticationUser(String userId, String email, String phone, String password) {
+    this.userId = userId;
     this.email = email;
     this.phone = phone;
+    this.password = password;
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of();
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getUsername() {
+    //userId는 식별자
+    return userId;
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
   }
 }

--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/CustomUserDetailService.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/CustomUserDetailService.java
@@ -18,18 +18,16 @@ public class CustomUserDetailService implements UserDetailsService {
 
   @Override
   public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-    UserResponse result = fetchUserUseCase.findUserByUserId(username);
+    UserResponse user = fetchUserUseCase.findUserByUserId(username);
 
-
-    return
-        new AuthenticationUser(
-            result.getUserId(),
-            result.getPassword(),
-            List.of(
-                new SimpleGrantedAuthority("ROLE_USER")
-            ),
-            result.getEmail(),
-            result.getPhone()
-        );
+    List<SimpleGrantedAuthority> authorities = List.of(
+        new SimpleGrantedAuthority(user.getUserType())
+    );
+    return new AuthenticationUser(
+        user.getUserId(),
+        user.getEmail(),
+        user.getPhone(),
+        user.getPassword()
+    );
   }
 }

--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/JwtTokenProvider.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/JwtTokenProvider.java
@@ -1,15 +1,14 @@
 package com.threadly.auth;
 
-import static com.threadly.util.LogFormatUtils.*;
+import static com.threadly.util.LogFormatUtils.logFailure;
+import static com.threadly.util.LogFormatUtils.logSuccess;
 
 import com.threadly.ErrorCode;
 import com.threadly.auth.token.response.LoginTokenResponse;
 import com.threadly.exception.token.TokenException;
 import com.threadly.properties.TtlProperties;
-import com.threadly.token.InsertTokenPort;
 import com.threadly.user.FetchUserUseCase;
 import com.threadly.user.response.UserResponse;
-import com.threadly.util.LogFormatUtils;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -23,14 +22,10 @@ import java.util.List;
 import java.util.UUID;
 import javax.crypto.SecretKey;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -59,17 +54,16 @@ public class JwtTokenProvider {
         new SimpleGrantedAuthority(user.getUserType())
     );
 
-    /*UserDetails 생성*/
-    UserDetails principal = new User(
+    AuthenticationUser authenticationUser = new AuthenticationUser(
         user.getUserId(),
-        StringUtils.isEmpty(
-            user.getPassword()) ? "password" : user.getPassword(),
-        authorities
+        user.getEmail(),
+        user.getPhone(),
+        user.getPassword()
     );
 
     return new UsernamePasswordAuthenticationToken(
-        principal,
-        user.getUserId(),
+        authenticationUser,
+        "",
         authorities
     );
 
@@ -182,6 +176,7 @@ public class JwtTokenProvider {
 
   /**
    * accessToken에서 남은 ttl 추출
+   *
    * @return
    */
   public Duration getAccessTokenTtl(String accessToken) {

--- a/threadly-apps/app-api/src/main/java/com/threadly/auth/controller/AuthController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.threadly.auth.controller;
 
 import com.threadly.auth.AuthManager;
+import com.threadly.auth.AuthenticationUser;
 import com.threadly.auth.token.response.LoginTokenResponse;
 import com.threadly.auth.token.response.TokenReissueResponse;
 import com.threadly.auth.verification.EmailVerificationUseCase;
@@ -10,6 +11,7 @@ import com.threadly.auth.request.PasswordVerificationRequest;
 import com.threadly.auth.request.UserLoginRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -81,14 +83,11 @@ public class AuthController {
    */
   @PostMapping("/verify-password")
   public PasswordVerificationToken verifyPassword(
+      @AuthenticationPrincipal AuthenticationUser user,
       @RequestBody PasswordVerificationRequest request) {
 
-    /*userId 추출*/
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
-
     return
-        passwordVerificationUseCase.getPasswordVerificationToken(userId, request.getPassword());
+        passwordVerificationUseCase.getPasswordVerificationToken(user.getUserId(), request.getPassword());
 
   }
 

--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentLikeController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostCommentLikeController.java
@@ -1,5 +1,6 @@
 package com.threadly.post.controller;
 
+import com.threadly.auth.AuthenticationUser;
 import com.threadly.post.like.comment.GetPostCommentLikersApiResponse;
 import com.threadly.post.like.comment.GetPostCommentLikersQuery;
 import com.threadly.post.like.comment.GetPostCommentLikersUseCase;
@@ -10,8 +11,7 @@ import com.threadly.post.like.comment.UnlikePostCommentUseCase;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,15 +73,14 @@ public class PostCommentLikeController {
    */
   @PostMapping("/{postId}/comments/{commentId}/likes")
   public ResponseEntity<LikePostCommentApiResponse> likePostComment(
+      @AuthenticationPrincipal AuthenticationUser user,
       @PathVariable("postId") String postId, @PathVariable("commentId") String commentId
   ) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
 
     LikePostCommentApiResponse likePostCommentApiResponse = likePostCommentUseCase.likePostComment(
         new LikePostCommentCommand(
             commentId,
-            userId
+            user.getUserId()
         )
     );
 
@@ -95,19 +94,13 @@ public class PostCommentLikeController {
    */
   @DeleteMapping("/{postId}/comments/{commentId}/likes")
   public ResponseEntity<LikePostCommentApiResponse> cancelPostCommentLike(
+      @AuthenticationPrincipal AuthenticationUser user,
       @PathVariable("postId") String postId, @PathVariable("commentId") String commentId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
 
     return ResponseEntity.status(204).body(
         unlikePostCommentUseCase.cancelPostCommentLike(
             new LikePostCommentCommand(
                 commentId,
-                userId
-            )
-        )
-    );
+                user.getUserId())));
   }
-
-
 }

--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostLikeController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostLikeController.java
@@ -1,5 +1,6 @@
 package com.threadly.post.controller;
 
+import com.threadly.auth.AuthenticationUser;
 import com.threadly.post.engagement.GetPostEngagementApiResponse;
 import com.threadly.post.engagement.GetPostEngagementQuery;
 import com.threadly.post.engagement.GetPostEngagementUseCase;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -52,13 +54,12 @@ public class PostLikeController {
    */
   @GetMapping("/{postId}/engagement")
   public ResponseEntity<GetPostEngagementApiResponse> getPostEngagement(
+      @AuthenticationPrincipal AuthenticationUser user,
       @PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
 
     return ResponseEntity.status(200).body(getPostEngagementUsecase.getPostEngagement(
         new GetPostEngagementQuery(
-            postId, userId
+            postId, user.getUserId()
         )
     ));
   }
@@ -92,15 +93,15 @@ public class PostLikeController {
    * @return
    */
   @PostMapping("/{postId}/likes")
-  public ResponseEntity<LikePostApiResponse> likePost(@PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
+  public ResponseEntity<LikePostApiResponse> likePost(
+      @AuthenticationPrincipal AuthenticationUser user,
+      @PathVariable("postId") String postId) {
 
     return ResponseEntity.status(200).body(
         likePostUseCase.likePost(
             new LikePostCommand(
                 postId,
-                userId
+                user.getUserId()
             )
         )
     );
@@ -113,14 +114,14 @@ public class PostLikeController {
    * @return
    */
   @DeleteMapping("/{postId}/likes")
-  public ResponseEntity<LikePostApiResponse> cancelPostLike(@PathVariable("postId") String postId) {
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
+  public ResponseEntity<LikePostApiResponse> cancelPostLike(
+      @AuthenticationPrincipal AuthenticationUser user,
+      @PathVariable("postId") String postId) {
 
     return ResponseEntity.status(204).body(unlikePostUseCase.cancelLikePost(
         new LikePostCommand(
             postId,
-            userId
+            user.getUserId()
         )
     ));
   }

--- a/threadly-apps/app-api/src/main/java/com/threadly/user/controller/UserController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.threadly.user.controller;
 
+import com.threadly.auth.AuthenticationUser;
 import com.threadly.auth.verification.EmailVerificationUseCase;
 import com.threadly.user.RegisterUserUseCase;
 import com.threadly.user.UpdateUserUseCase;
@@ -14,6 +15,7 @@ import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,17 +61,14 @@ public class UserController {
 
   @PostMapping("/profile")
   public ResponseEntity<UserProfileApiResponse> setUserProfile(
+      @AuthenticationPrincipal AuthenticationUser user,
       @RequestBody CreateUserProfileRequest request) {
-    /*userId 추출*/
-    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    String userId = (String) auth.getCredentials();
 
-    URI location = URI.create("/api/users/" + userId);
+    URI location = URI.create("/api/users/" + user.getUserId());
 
     return ResponseEntity.created(location)
-//        .body(updateUserUseCase.upsertUserProfile(userId, userProfileRequestMapper.toCommand(request)));
         .body(updateUserUseCase.upsertUserProfile(new UserSetProfileCommand(
-                userId,
+                user.getUserId(),
                 request.getNickname(),
                 request.getStatusMessage(),
                 request.getBio(),


### PR DESCRIPTION
## 개요
기존에는 SecurityContextHolder에서 직접 Authentication 객체를 꺼내 userId를 가져오는 방식으로 인증 사용자 정보를 사용하고 있었음.  
이 방식은 테스트가 어렵고, Spring Security의 인증 주입 방식을 따르지 않아 유지보수성이 떨어졌음.  
이번 리팩토링에서는 `@AuthenticationPrincipal`을 통해 인증 객체를 주입받도록 개선하고,  
인증 객체인 `AuthenticationUser` 클래스도 필요 필드만 유지하도록 정비함.

## 주요 변경 사항
- UserController의 `setUserProfile()` 메서드에서 `@AuthenticationPrincipal AuthenticationUser` 사용하도록 수정
- 기존 `SecurityContextHolder` 직접 접근 방식 제거
- `AuthenticationUser` 클래스 리팩토링:
  - `authorities` 필드 제거
  - `getAuthorities()`는 `List.of()` 빈 목록 반환으로 처리
  - 사용자 정보 중심 필드 (`userId`, `email`, `phone`, `password`)만 유지
- Spring Security는 여전히 `UsernamePasswordAuthenticationToken`의 권한 정보를 기준으로 작동함

## 고려사항
- 해당 구조는 `AuthenticationUser`를 순수 사용자 정보 전용 객체로 사용하는 방식이며,
  권한 정보는 AuthenticationToken이 직접 관리함
- 이후 다른 컨트롤러 및 서비스에서도 동일한 방식으로 인증 정보 접근 방식을 통일해야 함
- 테스트 코드에서도 `@AuthenticationPrincipal` 기반 주입을 고려한 구조로 수정 필요