### PR TITLE
feat: TLY-67 게시글 수정 요청 응답 개선

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostController.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/post/controller/PostController.java
@@ -21,9 +21,7 @@ import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -138,7 +136,6 @@ public class PostController {
       @Valid @RequestBody UpdatePostRequest request,
       @PathVariable("postId") String postId) {
 
-
     return ResponseEntity.status(200).body(
         updatePostUseCase.updatePost(
             new UpdatePostCommand(postId, user.getUserId(), request.content())
@@ -156,7 +153,6 @@ public class PostController {
   public ResponseEntity<Void> deletePost(
       @AuthenticationPrincipal AuthenticationUser user,
       @PathVariable("postId") String postId) {
-
 
     deletePostUseCase.softDeletePost(
         new DeletePostCommand(postId, user.getUserId())

--- a/threadly-apps/app-api/src/test/java/com/threadly/post/controller/view/IncreaseViewCountApiTest.java
+++ b/threadly-apps/app-api/src/test/java/com/threadly/post/controller/view/IncreaseViewCountApiTest.java
@@ -91,8 +91,8 @@ public class IncreaseViewCountApiTest extends BasePostApiTest {
 
         CommonResponse<GetPostDetailApiResponse> getPostResponse2 = sendGetPostRequest(accessToken,
             VIEW_COUNT_ZERO_POST_ID, status().isOk());
-        int viewCount1 = getPostResponse1.getData().viewCount();
-        int viewCount2 = getPostResponse2.getData().viewCount();
+        long viewCount1 = getPostResponse1.getData().viewCount();
+        long viewCount2 = getPostResponse2.getData().viewCount();
 
         assertThat(viewCount1).isNotEqualTo(viewCount2);
         assertThat(viewCount2).isEqualTo(viewCount1 + 1);
@@ -145,8 +145,8 @@ public class IncreaseViewCountApiTest extends BasePostApiTest {
         CommonResponse<GetPostDetailApiResponse> getPostResponse2 = sendGetPostRequest(accessToken,
             VIEW_COUNT_ZERO_POST_ID, status().isOk());
 
-        int viewCount1 = getPostResponse1.getData().viewCount();
-        int viewCount2 = getPostResponse2.getData().viewCount();
+        long viewCount1 = getPostResponse1.getData().viewCount();
+        long viewCount2 = getPostResponse2.getData().viewCount();
 
         assertThat(viewCount1).isNotEqualTo(viewCount2);
         assertThat(viewCount2).isEqualTo(viewCount1 + 1);

--- a/threadly-core/core-port/src/main/java/com/threadly/post/fetch/PostDetailProjection.java
+++ b/threadly-core/core-port/src/main/java/com/threadly/post/fetch/PostDetailProjection.java
@@ -18,7 +18,7 @@ public interface PostDetailProjection {
 
   String getContent();
 
-  int getViewCount();
+  long getViewCount();
 
   LocalDateTime getPostedAt();
 

--- a/threadly-core/core-service/src/main/java/com/threadly/post/PostCommandService.java
+++ b/threadly-core/core-service/src/main/java/com/threadly/post/PostCommandService.java
@@ -12,6 +12,7 @@ import com.threadly.post.create.CreatePostUseCase;
 import com.threadly.post.delete.DeletePostCommand;
 import com.threadly.post.delete.DeletePostUseCase;
 import com.threadly.post.fetch.FetchPostPort;
+import com.threadly.post.fetch.PostDetailProjection;
 import com.threadly.post.save.SavePostPort;
 import com.threadly.post.update.UpdatePostApiResponse;
 import com.threadly.post.update.UpdatePostCommand;
@@ -66,6 +67,7 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
         savedPost.getContent(),
         0,
         0,
+        0,
         savedPost.getPostedAt()
     );
   }
@@ -81,23 +83,25 @@ public class PostCommandService implements CreatePostUseCase, UpdatePostUseCase,
       throw new PostException(ErrorCode.POST_UPDATE_FORBIDDEN);
     }
 
-    /*Post updatedPost = 사용자 조회*/
-    UserProfile userProfile = getUserProfile(command.getUserId());
-
     /*게시글 수정*/
     post.updateContent(command.getContent());
     updatePostPort.updatePost(post);
 
-    /*TODO 게시글 조회수 조회 로직 추가*/
+    PostDetailProjection updatePost = fetchPostPort.fetchPostDetailsByPostIdAndUserId(
+            command.getPostId(), command.getUserId())
+        .orElseThrow(() -> new PostException(ErrorCode.POST_NOT_FOUND));
 
     return new UpdatePostApiResponse(
-        post.getPostId(),
-        userProfile.getProfileImageUrl(),
-        userProfile.getNickname(),
-        post.getUserId(),
-        post.getContent(),
-        0, 0,
-        post.getPostedAt()
+        updatePost.getPostId(),
+        updatePost.getUserId(),
+        updatePost.getUserProfileImageUrl(),
+        updatePost.getUserNickname(),
+        updatePost.getContent(),
+        updatePost.getViewCount(),
+        updatePost.getPostedAt(),
+        updatePost.getLikeCount(),
+        updatePost.getCommentCount(),
+        updatePost.isLiked()
     );
   }
 

--- a/threadly-core/core-usecase/src/main/java/com/threadly/post/create/CreatePostApiResponse.java
+++ b/threadly-core/core-usecase/src/main/java/com/threadly/post/create/CreatePostApiResponse.java
@@ -19,6 +19,7 @@ public record CreatePostApiResponse(
     String userNickName,
     String userId,
     String content,
+    long viewCount,
     int likesCount,
     int commentsCount,
     LocalDateTime createdAt

--- a/threadly-core/core-usecase/src/main/java/com/threadly/post/get/GetPostDetailApiResponse.java
+++ b/threadly-core/core-usecase/src/main/java/com/threadly/post/get/GetPostDetailApiResponse.java
@@ -11,7 +11,7 @@ public record GetPostDetailApiResponse(
     String userProfileImageUrl,
     String userNickname,
     String content,
-    int viewCount,
+    long viewCount,
     LocalDateTime postedAt,
     long likeCount,
     long commentCount,

--- a/threadly-core/core-usecase/src/main/java/com/threadly/post/update/UpdatePostApiResponse.java
+++ b/threadly-core/core-usecase/src/main/java/com/threadly/post/update/UpdatePostApiResponse.java
@@ -4,24 +4,18 @@ import java.time.LocalDateTime;
 
 /**
  * 게시글 수정 API 응답 DTO
- * @param postId
- * @param userProfileImageUrl
- * @param userNickName
- * @param userId
- * @param content
- * @param likesCount
- * @param commentsCount
- * @param createdAt
  */
 public record UpdatePostApiResponse(
     String postId,
-    String userProfileImageUrl,
-    String userNickName,
     String userId,
+    String userProfileImageUrl,
+    String userNickname,
     String content,
-    int likesCount,
-    int commentsCount,
-    LocalDateTime createdAt
+    long viewCount,
+    LocalDateTime postedAt,
+    long likeCount,
+    long commentCount,
+    boolean liked
 
 ) {
 


### PR DESCRIPTION
## 개요

게시글 수정 후 클라이언트에 응답으로 전달하는 데이터의 정확성을 높이기 위해  
기존의 단순 수정 완료 응답 방식을 개선하여, **DB에서 수정된 게시글 정보를 다시 조회한 뒤 응답**하도록 로직을 변경하였습니다.  
또한, 응답 객체(`UpdatePostApiResponse`)의 필드를 보완하여 필요한 정보를 더 풍부하게 전달할 수 있게 구성하였습니다.

## 주요 변경 사항

- 게시글 수정 후, 변경된 게시글 정보를 다시 DB에서 조회 (`fetchPostDetailsByPostIdAndUserId`)
- `UpdatePostApiResponse` 개선
  - userNickname, profileImageUrl, likeCount, commentCount, liked, viewCount 등 상세 정보 포함
- 수정된 정보를 기반으로 클라이언트 UI 갱신이 가능하도록 일관된 응답 포맷 제공
- viewCount를 Long 타입으로 변경

## 고려사항

- 기존 조회 API(`GetPostDetailApiResponse`)와 유사한 구조로 응답을 구성하여 프론트엔드 연동 시 혼란을 줄임
- postId, userId 외 추가 데이터가 필요한 경우 Projection 객체 확장으로 대응
- 추후 게시글 수정 외 다른 API에도 동일한 응답 전략을 적용 가능