### PR TITLE
chore:TLY-112 운영환경 systemd 전용 스크립트 생성 및 기존 blue-green 배포 스크립트 리팩터링

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,12 +2,13 @@ name: CD
 
 on:
   push:
-    branches: [ master ]
-    paths-ignore:
-      - 'README.md'
-      - 'docs/**'
-      - '.github/**'
-      - '.gitignore'
+    branches: [ chore/TLY-112-systemd-service]
+#    branches: [ master ]
+#    paths-ignore:
+#      - 'README.md'
+#      - 'docs/**'
+#      - '.github/**'
+#      - '.gitignore'
   workflow_dispatch:
 concurrency:
   group: deploy-master
@@ -67,6 +68,7 @@ jobs:
           mkdir -p ./deploy/scripts
           cp ./infra/scripts/blue-green-deploy.sh ./deploy/scripts/
           cp ./infra/scripts/clean-old-images.sh ./deploy/scripts/
+          cp ./infra/scripts/start-threadly.sh ./deploy/scripts
 
       - name: Artifact 업로드
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,13 +2,12 @@ name: CD
 
 on:
   push:
-    branches: [ chore/TLY-112-systemd-service]
-#    branches: [ master ]
-#    paths-ignore:
-#      - 'README.md'
-#      - 'docs/**'
-#      - '.github/**'
-#      - '.gitignore'
+    branches: [ master ]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      - '.github/**'
+      - '.gitignore'
   workflow_dispatch:
 concurrency:
   group: deploy-master

--- a/infra/compose/prod/kafka/docker-compose.yml
+++ b/infra/compose/prod/kafka/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: confluentinc/cp-kafka:7.4.0
     depends_on:
       - zookeeper
-    #    ports:
-    #      - "9092:9092"
+    ports:
+      - "9092:9092"
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
@@ -29,8 +29,8 @@ services:
     mem_limit: 350m
     cpus: 0.3
     restart: unless-stopped
-    #    ports:
-    #      - "2181:2181"
+    ports:
+      - "2181:2181"
     networks:
       - kafka-network
 

--- a/infra/scripts/start-threadly.sh
+++ b/infra/scripts/start-threadly.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+#설정
+BASE_DIR="/home/ubuntu/threadly"
+INFRA_DIR="$BASE_DIR/infra/app"
+LOG_DIR="$BASE_DIR/logs/scripts"
+LOG_FILE="$LOG_DIR/start-threadly.log"
+NGINX_CONF="/etc/nginx/sites-available/default"
+HEALTH_PATH="/actuator/health"
+MAX_RETRIES=10
+SLEEP_SEC=10
+
+# 로깅
+mkdir -p "$(dirname "$LOG_FILE")"
+
+_ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(_ts)] [INFO ] $*" | tee -a "$LOG_FILE";}
+warn() { echo "[$(_ts)] [WARN ] $*" | tee -a "$LOG_FILE" >&2;}
+error() { echo "[$(_ts)] [ERROR ] $*"| tee -a "$LOG_FILE" >&2;}
+
+parse_current_port(){
+  local port
+  port=$(grep -Eo 'proxy_pass\s+http://[^:]+:([0-9]+);' "$NGINX_CONF" | awk -F: '{print $NF}' | tr -d ';' | tail -n1)
+  [[ -n "${port:-}" ]] || { error "NGINX proxy_pass 포트 파싱 실패: $NGINX_CONF"; exit 1; }
+  echo "$port"
+}
+
+compose_file_for(){
+  local slot="$1"
+  local f="$INFRA_DIR/docker-compose.${slot}.yml"
+  echo "$f"
+}
+
+compose_up(){
+  local slot="$1"
+  local f; f="$(compose_file_for "$slot")"
+  log "docker compose up -d ($slot): $f"
+  docker compose -f "$f" -p "$slot" up -d
+}
+
+compose_down(){
+  local slot="$1"
+  local f; f="$(compose_file_for "$slot")"
+  warn "docker compose down ($slot): $f"
+  docker compose -f "$f" -p "$slot" down || true
+}
+
+health_check(){
+local port="$1"
+local url="http://localhost:${port}${HEALTH_PATH}"
+
+log "Health Check 시작..."
+
+local i
+for((i=1; i<=MAX_RETRIES; i++)); do
+  if curl -fsS "$url" >/dev/null 2>&1; then
+    log "Health check 성공!"
+    return 0
+  fi
+  log "재시도.."
+  sleep "$SLEEP_SEC"
+done
+return 1
+}
+
+log "======Threadly Service Start======"
+
+CURRENT_PORT="$(parse_current_port)"
+case "$CURRENT_PORT" in
+  8080) SLOT="blue" ;;
+  8081) SLOT="green" ;;
+  *)    error "지원하지 않는 포트: $CURRENT_PORT"; exit 1;;
+esac
+log "현재 Nginx 대상: $SLOT ($CURRENT_PORT)"
+
+compose_up "$SLOT"
+
+sleep "$SLEEP_SEC"
+
+if ! health_check "$CURRENT_PORT"; then
+  error "Health Check 실패 -> 롤백"
+  compose_down "$SLOT"
+  exit 1
+fi
+
+log "Threadly Service 부팅 성공"
+log "======Finish======"


### PR DESCRIPTION
# TLY-112: 운영환경 systemd 전용 스크립트 생성 및 기존 blue-green 배포 스크립트 리팩터링

## 개요
- systemd 서비스에서 불필요한 blue-green 무중단 배포 로직이 실행되는 문제 해결
- 서버 부팅용과 배포용 스크립트 분리를 통한 책임 분리 및 성능 최적화
- blue-green 배포 스크립트 구조 개선 및 리팩터링

## 주요 변경 사항
- **신규 스크립트 생성**: `/infra/scripts/start-threadly.sh` - systemd 전용 서비스 시작 스크립트
- **스크립트 리팩터링**: `blue-green-deploy.sh` 함수 기반 구조로 전면 개선
- **함수 분리**: 공통 기능을 재사용 가능한 함수로 추출
  - `parse_current_port()`: nginx 포트 파싱
  - `compose_up()` / `compose_down()`: 컨테이너 제어
  - `health_check()`: 헬스체크 수행
  - `nginx_port_change()`: nginx 포트 전환
- **에러 처리 강화**: `set -euo pipefail` 적용으로 스크립트 안정성 향상
- **로깅 시스템 표준화**: 타임스탬프 및 로그 레벨 통일
- **CD 파이프라인 업데이트**: 새로운 스크립트 배포 과정에 포함
- **Kafka 포트 설정 조정**: 외부 접근을 위한 포트 매핑 활성화

## 고려사항
- **향후 notification-service 배포 시**: 동일한 패턴으로 systemd 전용 스크립트 필요
- **모니터링 강화**: 새로운 스크립트들의 로그 수집 및 모니터링 대시보드 추가