### PR TITLE
fix: 토큰 재발급 요청 시 CORS 오류 문제 해결

### DIFF
--- a/threadly-apps/app-api/src/main/java/com/threadly/config/SecurityConfig.java
+++ b/threadly-apps/app-api/src/main/java/com/threadly/config/SecurityConfig.java
@@ -53,7 +53,13 @@ public class SecurityConfig {
     config.setAllowedMethods(
         Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"));
     config.setAllowedHeaders(
-        Arrays.asList("Authorization", "Accept", "Content-Type", "Origin", "X-Requested-With"));
+        Arrays.asList(
+            "Authorization",
+            "Accept",
+            "Content-Type",
+            "Origin",
+            "X-Requested-With",
+            "X-refresh-token"));
     config.setAllowCredentials(true);
     config.setMaxAge(3600L);
 


### PR DESCRIPTION
## 관련 이슈
#88 


## 주요 변경 사항
- CORS 설정의 `setAllowedHeaders`에 토큰 재발급시 사용되는 `X-refresh-token` 누락
- 토큰 재발급 요청 시 CORS 문제 발견 버그 픽스

## 고려사항
