### PR TITLE
fix: userProfileImageUrl 조회 시 쿼리 오류 해결

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
@@ -270,8 +270,8 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, String> {
   /**
    * 주어진 targetUserId에 해당하는 사용자의 게시글 목록 커서 기반 조회
    *
-   * @param requestUserId 요청자 ID (좋아요 여부 확인용)
-   * @param targetUserId 대상 사용자 ID (게시글 필터링용)
+   * @param requestUserId  요청자 ID (좋아요 여부 확인용)
+   * @param targetUserId   대상 사용자 ID (게시글 필터링용)
    * @param cursorPostedAt
    * @param cursorPostId
    * @param limit
@@ -294,7 +294,7 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, String> {
                join user_profile up on u.user_id = up.user_id
                left join (select upi.user_id, upi.image_url
                           from user_profile_images upi
-                          where upi.status = 'APPROVED') upi
+                          where upi.status = 'CONFIRMED') upi
                          on u.user_id = upi.user_id
                left join(select pc.post_id, count(*) as cnt
                          from post_comments pc


### PR DESCRIPTION
## 개요
- 특정 사용자의 게시글 목록 조회 시 작성자의 profileImageUrl이 null로 나오는 문제 해결

## 주요 변경 사항
- 해당 쿼리의 조건에서 `APPROVED`를 `CONFIRMED`로 변경

## 고려사항
- native query 사용시에는 유의