### PR TITLE
fix: 배포 시 업로드 이미지 손실 문제 해결

### DIFF
--- a/infra/compose/prod/app/docker-compose.blue.yml
+++ b/infra/compose/prod/app/docker-compose.blue.yml
@@ -28,6 +28,7 @@ services:
     restart: unless-stopped
     volumes:
       - /home/ubuntu/threadly/logs/services/app/blue:/app/logs
+      - /home/ubuntu/threadly/storage/uploads:/app/local-storage/uploads
     networks:
       - service-network
       - kafka-network

--- a/infra/compose/prod/app/docker-compose.green.yml
+++ b/infra/compose/prod/app/docker-compose.green.yml
@@ -26,6 +26,7 @@ services:
         max-file: "3"
     volumes:
       - /home/ubuntu/threadly/logs/services/app/green:/app/logs
+      - /home/ubuntu/threadly/storage/uploads:/app/local-storage/uploads
     networks:
       - service-network
       - kafka-network


### PR DESCRIPTION
## 개요
- 배포 시 docker container 내부에 저장되어 있던 업로드 파일이 사라지는 문제 해결

## 주요 변경 사항
- `blue-green` 방식의 배포 시 기존의 누락되었던 image 저장 경로를 로컬에 마운트

## 고려사항
- 마운트 되는 경로의 디렉토리 권한 주의