### PR TITLE
fix: 프로필 이미지 조회 시 중복 데이터 조회 문제 해결

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/follow/repository/FollowJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/follow/repository/FollowJpaRepository.java
@@ -104,7 +104,7 @@ public interface FollowJpaRepository extends JpaRepository<FollowEntity, String>
                     on target_user.user_id = uf.following_id and target_user.status = 'ACTIVE'
                join users u on u.user_id = uf.follower_id and u.status = 'ACTIVE'
                join user_profile up on up.user_id = uf.follower_id
-               left join user_profile_images upi on upi.user_id = uf.follower_id
+               left join user_profile_images upi on upi.user_id = uf.follower_id and upi.status = 'CONFIRMED'
       where uf.following_id = :targetUserId and uf.status = 'APPROVED'
         and (
         cast(:cursorTimestamp as timestamp) is null
@@ -136,7 +136,7 @@ public interface FollowJpaRepository extends JpaRepository<FollowEntity, String>
                     on target_user.user_id = uf.follower_id and target_user.status = 'ACTIVE'
                join users u on u.user_id = uf.following_id and u.status = 'ACTIVE'
                join user_profile up on up.user_id = uf.following_id
-               left join user_profile_images upi on upi.user_id = uf.following_id
+               left join user_profile_images upi on upi.user_id = uf.following_id and upi.status = 'CONFIRMED'
       where uf.follower_id = :targetUserId and uf.status = 'APPROVED'
         and (
         cast(:cursorTimestamp as timestamp) is null

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/CommentLikeJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/CommentLikeJpaRepository.java
@@ -79,7 +79,7 @@ public interface CommentLikeJpaRepository extends JpaRepository<CommentLikeEntit
                join users u on cl.user_id = u.user_id
                join user_profile up on u.user_id = up.user_id
                join post_comments pc on cl.comment_id = pc.comment_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
       where pc.status = 'ACTIVE'
         and pc.comment_id = :commentId
         and (

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostCommentJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostCommentJpaRepository.java
@@ -47,7 +47,7 @@ public interface PostCommentJpaRepository extends JpaRepository<PostCommentEntit
       from post_comments pc
                join users u on pc.user_id = u.user_id
                join user_profile up on u.user_id = up.user_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
                left join(select comment_id,
                                 count(*) like_count,
                                 max(
@@ -79,7 +79,7 @@ public interface PostCommentJpaRepository extends JpaRepository<PostCommentEntit
       from post_comments pc
                join users u on pc.user_id = u.user_id
                join user_profile up on u.user_id = up.user_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
                left join(select comment_id,
                                 count(*) as like_count
                          from comment_likes

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostLikeJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostLikeJpaRepository.java
@@ -77,7 +77,7 @@ public interface PostLikeJpaRepository extends JpaRepository<PostLikeEntity, Str
       from post_likes pl
                join users u on pl.user_id = u.user_id
                join user_profile up on u.user_id = up.user_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
       where pl.post_id = :postId
        and (
        cast(:cursorLikedAt as timestamp) is null 

--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/user/repository/UserProfileJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/user/repository/UserProfileJpaRepository.java
@@ -79,7 +79,7 @@ public interface UserProfileJpaRepository extends JpaRepository<UserProfileEntit
              upi.image_url             as profileImageUrl
       from user_profile up
                join users u on up.user_id = u.user_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
                where up.user_id = :userId;
       """, nativeQuery = true)
   Optional<MyProfileDetailsProjection> findMyProfileDetailsByUserId(@Param("userId") String userId);


### PR DESCRIPTION
## 개요
- 프로필 이미지를 포함하는 쿼리 실행 시 중복 조회 문제 해결

## 주요 변경 사항
- 프로필 이미지를 포함하는 쿼리 실행 시 `Query did not return a unique result` 예외가 발생
- `left join`으로 프로필 이미지를 join 할 때 `status='CONFIRMED' 조건 추가

## 고려사항
- 추후 프로필 이미지가 존재하지 않는 경우 `null`을 리턴하지 않고 기본값을 정해서 리턴하도록 개선이 필요