### PR TITLE
fix: 프로필 이미지 조회 시 중복 데이터 조회 문제 해결 (#03)

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
@@ -55,7 +55,7 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, String> {
       from posts p
                join users u on p.user_id = u.user_id
                join user_profile up on u.user_id = up.user_id
-               left join user_profile_images upi on up.user_id = upi.user_id
+               left join user_profile_images upi on up.user_id = upi.user_id and upi.status = 'CONFIRMED'
                left join(select post_id,
                                 count(*) as like_count,
                                 max(


### PR DESCRIPTION
## 개요
- 버그 픽스 중 누락된 파일 반영

## 주요 변경 사항
- [fix: 프로필 이미지 조회 시 중복 데이터 조회 문제 해결 ](https://github.com/KimGyuBek/threadly-service/pull/95)에서 누락된 파일 반영

## 고려사항
- 