### PR TITLE
fix: 게시글 조회 시 삭제된 댓글까지 카운트 되는 문제 해결

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/post/repository/PostJpaRepository.java
@@ -110,6 +110,7 @@ public interface PostJpaRepository extends JpaRepository<PostEntity, String> {
                          group by post_id) pl_count on p.post_id = pl_count.post_id
                left join(select post_id, count(*) as comment_count
                          from post_comments
+                         where status = 'ACTIVE'
                          group by post_id) pc_count on p.post_id = pc_count.post_id
                left join(select post_id,
                                 true as liked


### PR DESCRIPTION
## 개요
- 게시글 조회 시 삭제된 댓글까지 카운트 되던 문제 해결

## 주요 변경 사항
- `left join`으로 댓글 조인 시 `status='ACTIVE` 조건 추가

## 고려사항
- 