### PR TITLE
fix: 팔로우 데이터가 없는 상황에서 사용자의 팔로워/팔로잉 수 조회 시 예외 발생 문제 해결

### DIFF
--- a/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/follow/repository/FollowJpaRepository.java
+++ b/threadly-adapters/adapter-persistence/src/main/java/com/threadly/adapter/persistence/follow/repository/FollowJpaRepository.java
@@ -1,7 +1,7 @@
 package com.threadly.adapter.persistence.follow.repository;
 
-import com.threadly.core.domain.follow.FollowStatus;
 import com.threadly.adapter.persistence.follow.entity.FollowEntity;
+import com.threadly.core.domain.follow.FollowStatus;
 import com.threadly.core.port.follow.out.projection.FollowRequestsProjection;
 import com.threadly.core.port.follow.out.projection.FollowerProjection;
 import com.threadly.core.port.follow.out.projection.FollowingProjection;
@@ -219,16 +219,20 @@ public interface FollowJpaRepository extends JpaRepository<FollowEntity, String>
    * @return
    */
   @Query(value = """
-      select sum(case
-                     when uf.following_id = :userId and uf.status = 'APPROVED' then 1
-                     else 0 end)                                                                  as followerCount,
-             sum(case
-                     when uf.follower_id = :userId and uf.status = 'APPROVED' then 1
-                     else 0 end)                                                                  as followingCount
-      from user_follows uf
-            join users u1 on uf.follower_id = u1.user_id and u1.status = 'ACTIVE'
-            join users u2 on uf.following_id = u2.user_id and u2.status = 'ACTIVE'
-      where (uf.following_id = :userId or uf.follower_id = :userId)
+      select coalesce(sum(case
+                              when uf.following_id = :userId and uf.status = 'APPROVED' and
+                                   follower.status = 'ACTIVE' then 1
+                              else 0 end), 0) as followerCount,
+             coalesce(sum(case
+                              when uf.follower_id = :userId and uf.status = 'APPROVED' and
+                                   following.status = 'ACTIVE' then 1
+                              else 0 end), 0) as followingCount
+      from users u
+               left join user_follows uf on (u.user_id = uf.following_id or u.user_id = uf.follower_id)
+               left join users follower on (uf.follower_id = follower.user_id)
+               left join users following on (uf.following_id = following.user_id)
+      where u.user_id = :userId
+        and u.status = 'ACTIVE';
       """, nativeQuery = true)
   UserFollowStatsProjection getUserFollowStatsByUserId(@Param("userId") String userId);
 }


### PR DESCRIPTION
## 관련 이슈
- #103 

## 주요 변경 사항
- 사용자의 팔로우 데이터 수를 조회하는 쿼리 변경

## 고려사항
- 